### PR TITLE
KAN-63-[BE]JWT구현

### DIFF
--- a/back/moya/src/main/java/com/study/moya/auth/constants/JwtConstants.java
+++ b/back/moya/src/main/java/com/study/moya/auth/constants/JwtConstants.java
@@ -1,0 +1,16 @@
+package com.study.moya.auth.constants;
+
+public final class JwtConstants {
+    private JwtConstants() {}
+
+    public static final String AUTHORITIES_KEY = "auth";
+    public static final String BEARER_TYPE = "Bearer";
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String BEARER_PREFIX = "Bearer ";
+
+    public static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30;            // 30분
+    public static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;  // 7일
+
+    public static final String USER_ID_CLAIM = "id";
+    public static final String USER_NAME_CLAIM = "name";
+}

--- a/back/moya/src/main/java/com/study/moya/auth/controller/AuthController.java
+++ b/back/moya/src/main/java/com/study/moya/auth/controller/AuthController.java
@@ -1,0 +1,127 @@
+package com.study.moya.auth.controller;
+
+import com.study.moya.auth.dto.LoginRequest;
+import com.study.moya.auth.dto.SignupRequest;
+import com.study.moya.auth.dto.UserInfoResponse;
+import com.study.moya.auth.exception.InvalidRefreshTokenException;
+import com.study.moya.auth.jwt.JwtTokenProvider.TokenInfo;
+import com.study.moya.auth.service.AuthService;
+import com.study.moya.member.repository.MemberRepository;
+import com.study.moya.member.service.MemberService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@Slf4j
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+@Tag(name = "인증", description = "사용자 인증 및 등록을 위한 API")
+public class AuthController {
+
+    private final AuthService authService;
+    private final MemberService memberService;
+    private final MemberRepository memberRepository;
+
+    @PostMapping("/signup")
+    public ResponseEntity<?> registerUser(@Valid @RequestBody SignupRequest signUpRequest) {
+        memberService.registerNewUser(signUpRequest);
+        return ResponseEntity.ok("회원가입이 성공적으로 이루어졌습니다");
+    }
+
+    @GetMapping("/user")
+    public ResponseEntity<UserInfoResponse> getUserInfo(Authentication authentication) {
+        UserInfoResponse userInfoResponse = authService.getUserInfo(authentication);
+        return ResponseEntity.ok(userInfoResponse);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<?> authenticateUser(@Valid @RequestBody LoginRequest loginRequest,
+                                              HttpServletResponse response) {
+        log.info("로그인 요청 시작 - 이메일: {}", loginRequest.email());
+        try {
+            TokenInfo tokenInfo = authService.authenticateUser(loginRequest);
+            log.info("토큰 생성 완료");
+
+            // Access Token은 응답 본문에 포함
+            Map<String, String> tokenResponse = new HashMap<>();
+            tokenResponse.put("accessToken", tokenInfo.getAccessToken());
+
+            // Refresh Token은 쿠키에 설정
+            addRefreshTokenCookie(response, tokenInfo.getRefreshToken());
+            log.info("토큰 쿠키 설정 완료");
+
+            return ResponseEntity.ok(tokenResponse);
+        } catch (Exception e) {
+            log.error("로그인 처리 중 오류 발생: {}", e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<?> refreshToken(@CookieValue(name = "refresh_token", required = false) String refreshToken,
+                                          HttpServletResponse response) {
+        if (refreshToken == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body("리프레시 토큰이 없습니다.");
+        }
+
+        try {
+            TokenInfo tokenInfo = authService.refreshToken(refreshToken);
+
+            // 새로운 Access Token을 응답 본문에 포함
+            Map<String, String> tokenResponse = new HashMap<>();
+            tokenResponse.put("accessToken", tokenInfo.getAccessToken());
+
+            // 새로운 Refresh Token을 쿠키에 설정
+            addRefreshTokenCookie(response, tokenInfo.getRefreshToken());
+
+            return ResponseEntity.ok(tokenResponse);
+        } catch (InvalidRefreshTokenException e) {
+            // Refresh Token이 유효하지 않은 경우 쿠키 삭제
+            deleteRefreshTokenCookie(response);
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(e.getMessage());
+        }
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(HttpServletRequest request, HttpServletResponse response) {
+        //deleteRefreshTokenCookie(response);
+        log.info("로그아웃 성공");
+        return ResponseEntity.ok().body("로그아웃되었습니다");
+    }
+
+    private void addRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+        Cookie cookie = new Cookie("refresh_token", refreshToken);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        cookie.setSecure(true); // HTTPS 환경에서만 사용
+        cookie.setMaxAge(604800); // 7일
+        response.addCookie(cookie);
+    }
+
+    private void deleteRefreshTokenCookie(HttpServletResponse response) {
+        Cookie cookie = new Cookie("refresh_token", null);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/auth/domain/RefreshToken.java
+++ b/back/moya/src/main/java/com/study/moya/auth/domain/RefreshToken.java
@@ -1,0 +1,48 @@
+package com.study.moya.auth.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "refresh_token",
+        indexes = {
+                @Index(name = "idx_member_email", columnList = "memberEmail"),
+                @Index(name = "idx_token", columnList = "token", unique = true)
+        })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @Column(nullable = false)
+    private String memberEmail;
+
+    @Column(nullable = false)
+    private LocalDateTime expiryDate;
+
+    public RefreshToken(String token, String memberEmail, LocalDateTime expiryDate) {
+        this.token = token;
+        this.memberEmail = memberEmail;
+        this.expiryDate = expiryDate;
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiryDate);
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/auth/dto/LoginRequest.java
+++ b/back/moya/src/main/java/com/study/moya/auth/dto/LoginRequest.java
@@ -1,0 +1,26 @@
+package com.study.moya.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "로그인 요청 데이터")
+public record LoginRequest(
+        @Schema(description = "이메일 주소", example = "user@example.com")
+        @NotBlank(message = ErrorMessages.EMAIL_REQUIRED)
+        @Email(message = ErrorMessages.EMAIL_INVALID)
+        String email,
+
+        @Schema(description = "비밀번호", example = "strongPassword123!")
+        @NotBlank(message = ErrorMessages.PASSWORD_REQUIRED)
+        String password
+)
+
+{
+
+    public static final class ErrorMessages {
+        public static final String EMAIL_REQUIRED = "이메일은 필수입니다";
+        public static final String EMAIL_INVALID = "올바른 이메일 형식이어야 합니다";
+        public static final String PASSWORD_REQUIRED = "비밀번호는 필수입니다";
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/auth/dto/LoginResponseDto.java
+++ b/back/moya/src/main/java/com/study/moya/auth/dto/LoginResponseDto.java
@@ -1,0 +1,3 @@
+package com.study.moya.auth.dto;
+
+public record LoginResponseDto(String token) {}

--- a/back/moya/src/main/java/com/study/moya/auth/dto/SignupRequest.java
+++ b/back/moya/src/main/java/com/study/moya/auth/dto/SignupRequest.java
@@ -1,0 +1,72 @@
+package com.study.moya.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "회원가입 요청 데이터")
+public record SignupRequest(
+        @Schema(description = "이메일 주소", example = "user@example.com")
+        @NotBlank(message = ErrorMessages.EMAIL_REQUIRED)
+        @Email(message = ErrorMessages.EMAIL_INVALID)
+        String email,
+
+        @Schema(description = "비밀번호", example = "strongPassword123!",
+                minLength = Password.MIN_LENGTH, maxLength = Password.MAX_LENGTH)
+        @NotBlank(message = ErrorMessages.PASSWORD_REQUIRED)
+        @Size(min = Password.MIN_LENGTH, max = Password.MAX_LENGTH, message = Password.MESSAGE)
+        @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[@#$%^&+=!]).*$",
+                message = ErrorMessages.PASSWORD_PATTERN)
+        String password,
+
+        @Schema(description = "닉네임", example = "닉네임123",
+                minLength = Nickname.MIN_LENGTH, maxLength = Nickname.MAX_LENGTH)
+        @NotBlank(message = ErrorMessages.NICKNAME_REQUIRED)
+        @Size(min = Nickname.MIN_LENGTH, max = Nickname.MAX_LENGTH, message = Nickname.MESSAGE)
+        String nickname,
+
+        @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg")
+        String profileImageUrl,
+
+        @Schema(description = "제공자 ID", example = "kakao_12345")
+        String providerId,
+
+        @Schema(description = "이용약관 동의 여부", required = true)
+        @NotNull(message = ErrorMessages.TERMS_REQUIRED)
+        Boolean termsAgreed,
+
+        @Schema(description = "개인정보 처리방침 동의 여부", required = true)
+        @NotNull(message = ErrorMessages.PRIVACY_POLICY_REQUIRED)
+        Boolean privacyPolicyAgreed,
+
+        @Schema(description = "마케팅 수신 동의 여부")
+        Boolean marketingAgreed
+) {
+    public static final class Nickname {
+        public static final int MIN_LENGTH = 2;
+        public static final int MAX_LENGTH = 30;
+        public static final String MESSAGE =
+                "닉네임은 반드시 " + MIN_LENGTH + "자 이상 " + MAX_LENGTH + "자 이하여야 합니다";
+    }
+
+    public static final class Password {
+        public static final int MIN_LENGTH = 8;
+        public static final int MAX_LENGTH = 40;
+        public static final String MESSAGE =
+                "비밀번호는 반드시 " + MIN_LENGTH + "자 이상 " + MAX_LENGTH + "자 이하여야 합니다";
+    }
+
+    public static final class ErrorMessages {
+        public static final String EMAIL_REQUIRED = "이메일은 필수입니다";
+        public static final String EMAIL_INVALID = "올바른 이메일 형식이어야 합니다";
+        public static final String PASSWORD_REQUIRED = "비밀번호는 필수입니다";
+        public static final String PASSWORD_PATTERN =
+                "비밀번호는 숫자, 소문자, 대문자, 특수문자를 각각 하나 이상 포함해야 합니다";
+        public static final String NICKNAME_REQUIRED = "닉네임은 필수입니다";
+        public static final String TERMS_REQUIRED = "이용약관 동의는 필수입니다";
+        public static final String PRIVACY_POLICY_REQUIRED = "개인정보 처리방침 동의는 필수입니다";
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/auth/dto/UserInfoResponse.java
+++ b/back/moya/src/main/java/com/study/moya/auth/dto/UserInfoResponse.java
@@ -1,0 +1,7 @@
+package com.study.moya.auth.dto;
+
+import com.study.moya.member.domain.Role;
+import java.util.Set;
+
+public record UserInfoResponse(String name, String email, Set<Role> roles) {
+}

--- a/back/moya/src/main/java/com/study/moya/auth/exception/EmailAlreadyExistsException.java
+++ b/back/moya/src/main/java/com/study/moya/auth/exception/EmailAlreadyExistsException.java
@@ -1,0 +1,14 @@
+
+package com.study.moya.auth.exception;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "이미 존재하는 이메일로 가입 시도 시 발생하는 예외")
+public class EmailAlreadyExistsException extends RuntimeException {
+
+    public static final String EMAIL_ALREADY_EXISTS = "해당 이메일은 이미 사용중 입니다: %s";
+
+    public EmailAlreadyExistsException(String email) {
+        super(String.format(EMAIL_ALREADY_EXISTS, email));
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/auth/exception/InvalidRefreshTokenException.java
+++ b/back/moya/src/main/java/com/study/moya/auth/exception/InvalidRefreshTokenException.java
@@ -1,0 +1,7 @@
+package com.study.moya.auth.exception;
+
+public class InvalidRefreshTokenException extends RuntimeException {
+    public InvalidRefreshTokenException(String message) {
+        super(message);
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/auth/exception/TokenProcessingException.java
+++ b/back/moya/src/main/java/com/study/moya/auth/exception/TokenProcessingException.java
@@ -1,0 +1,7 @@
+package com.study.moya.auth.exception;
+
+public class TokenProcessingException extends RuntimeException {
+    public TokenProcessingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/auth/exception/UserNotFoundException.java
+++ b/back/moya/src/main/java/com/study/moya/auth/exception/UserNotFoundException.java
@@ -1,0 +1,13 @@
+package com.study.moya.auth.exception;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "사용자를 찾을 수 없을 때 발생하는 예외")
+public class UserNotFoundException extends RuntimeException {
+
+    public static final String USER_NOT_FOUND = "해당 이메일로 가입된 정보가 없습니다: %s";
+
+    public UserNotFoundException(String email) {
+        super(String.format(USER_NOT_FOUND, email));
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/auth/jwt/JwtAuthenticationFilter.java
+++ b/back/moya/src/main/java/com/study/moya/auth/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,93 @@
+package com.study.moya.auth.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.study.moya.auth.dto.LoginRequest;
+import com.study.moya.auth.jwt.JwtTokenProvider.TokenInfo;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
+    public static final String HEADER_STRING = "Authorization";
+    public static final String CONTENT_TYPE_JSON = "application/json";
+    public static final String CHARSET_UTF8 = "UTF-8";
+    public static final String TOKEN_PREFIX = "Bearer ";
+    public static final String ERROR_AUTH_FAILED = "인증 실패: ";
+    public static final String ERROR_PARSE_FAILED = "인증 요청 파싱 실패";
+
+    private final AuthenticationManager authenticationManager;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request,
+                                                HttpServletResponse response) throws AuthenticationException {
+        try {
+            log.info("요청에 대한 인증 시도 중: {}", request.getRequestURI());
+            LoginRequest loginRequest = new ObjectMapper().readValue(request.getInputStream(), LoginRequest.class);
+            log.debug("이메일에 대한 로그인 요청 파싱 완료: {}", loginRequest.email());
+
+            UsernamePasswordAuthenticationToken authenticationToken = UsernamePasswordAuthenticationToken.unauthenticated(
+                    loginRequest.email(),
+                    loginRequest.password()
+            );
+
+            Authentication authentication = authenticationManager.authenticate(authenticationToken);
+            log.info("인증 시도 결과: {}", authentication.isAuthenticated() ? "성공" : "실패");
+            return authentication;
+        } catch (IOException e) {
+            log.error("인증 요청 파싱 실패", e);
+            throw new AuthenticationException(ERROR_PARSE_FAILED, e) {};
+        }
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response,
+                                            FilterChain chain, Authentication authResult)
+            throws IOException, ServletException {
+        log.info("사용자 인증 성공: {}", authResult.getName());
+
+        TokenInfo tokenInfo = jwtTokenProvider.createToken(authResult);
+        log.debug("토큰 생성 완료");
+
+        // Access Token은 헤더와 응답 본문에 포함
+        response.addHeader(HEADER_STRING, TOKEN_PREFIX + tokenInfo.getAccessToken());
+
+        // Refresh Token은 쿠키로 설정
+        Cookie refreshTokenCookie = new Cookie("refresh_token", tokenInfo.getRefreshToken());
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setSecure(true);
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setMaxAge(604800); // 7일
+        response.addCookie(refreshTokenCookie);
+
+        response.setContentType(CONTENT_TYPE_JSON);
+        response.setCharacterEncoding(CHARSET_UTF8);
+        response.getWriter().write("{\"accessToken\":\"" + tokenInfo.getAccessToken() + "\"}");
+
+        log.info("사용자에 대한 인증 응답 전송 완료: {}", authResult.getName());
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response,
+                                              AuthenticationException failed) throws IOException, ServletException {
+        log.warn("인증 실패: {}", failed.getMessage());
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(CONTENT_TYPE_JSON);
+        response.setCharacterEncoding(CHARSET_UTF8);
+        response.getWriter().write("{\"error\":\"" + ERROR_AUTH_FAILED + failed.getMessage() + "\"}");
+        log.info("인증 실패 응답 전송 완료");
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/auth/jwt/JwtAuthorizationFilter.java
+++ b/back/moya/src/main/java/com/study/moya/auth/jwt/JwtAuthorizationFilter.java
@@ -1,0 +1,114 @@
+package com.study.moya.auth.jwt;
+
+import com.study.moya.auth.jwt.JwtTokenProvider.TokenInfo;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final String REFRESH_TOKEN_COOKIE_NAME = "refresh_token";
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        log.debug("JwtAuthorizationFilter를 통해 요청 처리 중: {}", request.getRequestURI());
+
+        // 액세스 토큰 처리
+        String accessToken = resolveAccessToken(request);
+        log.debug("추출된 액세스 토큰: {}", accessToken != null ? "존재함" : "존재하지 않음");
+
+        if (StringUtils.hasText(accessToken) && jwtTokenProvider.validateToken(accessToken)) {
+            Authentication auth = jwtTokenProvider.getAuthentication(accessToken);
+            if (auth != null && auth.getPrincipal() != null) {
+                SecurityContextHolder.getContext().setAuthentication(auth);
+                log.info("'{}' 사용자에 대한 인증 정보를 보안 컨텍스트에 설정했습니다. URI: {}",
+                        auth.getName(), request.getRequestURI());
+            } else {
+                log.warn("인증 정보 설정에 실패했습니다. 인증 객체 또는 주체가 null입니다.");
+            }
+        } else {
+            // 액세스 토큰이 유효하지 않은 경우, 리프레시 토큰 확인
+            String refreshToken = resolveRefreshToken(request);
+            if (StringUtils.hasText(refreshToken) && shouldAttemptRefresh(request)) {
+                try {
+                    TokenInfo newTokens = jwtTokenProvider.refreshAccessToken(refreshToken);
+                    response.setHeader(AUTHORIZATION_HEADER, BEARER_PREFIX + newTokens.getAccessToken());
+
+                    // 새로운 리프레시 토큰을 쿠키에 설정
+                    addRefreshTokenCookie(response, newTokens.getRefreshToken());
+
+                    // 새로운 액세스 토큰으로 인증 설정
+                    Authentication auth = jwtTokenProvider.getAuthentication(newTokens.getAccessToken());
+                    SecurityContextHolder.getContext().setAuthentication(auth);
+
+                    log.info("토큰이 성공적으로 갱신되었습니다. 사용자: {}", auth.getName());
+                } catch (Exception e) {
+                    log.warn("토큰 갱신 실패: {}", e.getMessage());
+                }
+            } else {
+                log.debug("유효한 JWT 토큰을 찾을 수 없습니다. URI: {}", request.getRequestURI());
+            }
+        }
+
+        filterChain.doFilter(request, response);
+        log.debug("JwtAuthorizationFilter를 통한 요청 처리 완료: {}", request.getRequestURI());
+    }
+
+    private String resolveAccessToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            log.debug("Authorization 헤더에서 액세스 토큰을 찾았습니다");
+            return bearerToken.substring(BEARER_PREFIX.length());
+        }
+        log.debug("Authorization 헤더에서 액세스 토큰을 찾을 수 없습니다");
+        return null;
+    }
+
+    private String resolveRefreshToken(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (REFRESH_TOKEN_COOKIE_NAME.equals(cookie.getName())) {
+                    log.debug("쿠키에서 리프레시 토큰을 찾았습니다");
+                    return cookie.getValue();
+                }
+            }
+        }
+        log.debug("쿠키에서 리프레시 토큰을 찾을 수 없습니다");
+        return null;
+    }
+
+    private boolean shouldAttemptRefresh(HttpServletRequest request) {
+        // 토큰 갱신을 시도하지 않을 경로들
+        String path = request.getRequestURI();
+        return !path.equals("/api/auth/refresh") &&
+                !path.equals("/api/auth/login") &&
+                !path.equals("/api/auth/logout") &&
+                !path.equals("/api/auth/signup");
+    }
+
+    private void addRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+        Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true); // HTTPS 환경에서만 사용
+        cookie.setPath("/");
+        cookie.setMaxAge(604800); // 7일
+        response.addCookie(cookie);
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/auth/jwt/JwtTokenProvider.java
+++ b/back/moya/src/main/java/com/study/moya/auth/jwt/JwtTokenProvider.java
@@ -1,0 +1,197 @@
+package com.study.moya.auth.jwt;
+
+
+import com.study.moya.auth.domain.RefreshToken;
+import com.study.moya.auth.exception.InvalidRefreshTokenException;
+import com.study.moya.auth.exception.TokenProcessingException;
+import com.study.moya.auth.repository.RefreshTokenRepository;
+import com.study.moya.member.domain.Member;
+import com.study.moya.member.service.MemberService;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+import javax.crypto.SecretKey;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final ObjectProvider<MemberService> memberServiceProvider;
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    @Value("${jwt.access.expiration}")
+    private long accessTokenValidityInMilliseconds;
+
+    @Value("${jwt.refresh.expiration}")
+    private long refreshTokenValidityInMilliseconds;
+
+    private SecretKey key;
+
+    @PostConstruct
+    protected void init() {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+        log.info("JwtTokenProvider가 비밀 키로 초기화되었습니다");
+    }
+
+    @Transactional
+    public TokenInfo createToken(Authentication authentication) {
+        Member member = (Member) authentication.getPrincipal();
+        String username = member.getEmail();
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        // Access Token 생성
+        String accessToken = createAccessToken(username, authorities, member);
+
+        // Refresh Token 생성
+        String refreshToken = createRefreshToken(username);
+
+        log.info("사용자를 위한 토큰 생성 완료: {}", username);
+        return new TokenInfo(accessToken, refreshToken);
+    }
+
+    private String createAccessToken(String username, String authorities, Member member) {
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + accessTokenValidityInMilliseconds);
+
+        return Jwts.builder()
+                .subject(username)
+                .claim("auth", authorities)
+                .claim("id", member.getId())
+                .claim("name", member.getNickname())
+                .issuedAt(now)
+                .expiration(validity)
+                .signWith(key, Jwts.SIG.HS256)
+                .compact();
+    }
+
+    @Transactional
+    protected String createRefreshToken(String username) {
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + refreshTokenValidityInMilliseconds);
+
+        String refreshToken = Jwts.builder()
+                .subject(username)
+                .issuedAt(now)
+                .expiration(validity)
+                .signWith(key, Jwts.SIG.HS256)
+                .compact();
+
+        try {
+            // 기존 리프레시 토큰이 있다면 삭제
+            refreshTokenRepository.deleteByMemberEmail(username);
+
+            // 새로운 리프레시 토큰 저장
+            refreshTokenRepository.save(new RefreshToken(
+                    refreshToken,
+                    username,
+                    LocalDateTime.now().plusSeconds(refreshTokenValidityInMilliseconds / 1000)
+            ));
+
+            log.debug("리프레시 토큰 생성 및 저장 완료 - 사용자: {}", username);
+        } catch (Exception e) {
+            log.error("리프레시 토큰 처리 중 오류 발생 - 사용자: {}, 오류: {}", username, e.getMessage());
+            throw new TokenProcessingException("리프레시 토큰 처리 중 오류가 발생했습니다.", e);
+        }
+
+        return refreshToken;
+    }
+
+    @Transactional
+    public TokenInfo refreshAccessToken(String refreshToken) {
+        // 리프레시 토큰 유효성 검증
+        if (!validateToken(refreshToken)) {
+            throw new InvalidRefreshTokenException("유효하지 않은 리프레시 토큰입니다.");
+        }
+
+        // DB에서 리프레시 토큰 조회
+        RefreshToken refreshTokenEntity = refreshTokenRepository.findByToken(refreshToken)
+                .orElseThrow(() -> new InvalidRefreshTokenException("존재하지 않는 리프레시 토큰입니다."));
+
+        if (refreshTokenEntity.isExpired()) {
+            refreshTokenRepository.delete(refreshTokenEntity);
+            throw new InvalidRefreshTokenException("만료된 리프레시 토큰입니다.");
+        }
+
+        // 사용자 정보 조회
+        MemberService memberService = memberServiceProvider.getObject();
+        Member member = memberService.findByEmail(refreshTokenEntity.getMemberEmail());
+
+        // 새로운 액세스 토큰 생성
+        String authorities = member.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        String newAccessToken = createAccessToken(member.getEmail(), authorities, member);
+
+        // 새로운 리프레시 토큰 생성
+        String newRefreshToken = createRefreshToken(member.getEmail());
+
+        log.info("토큰 갱신 완료 - 사용자: {}", member.getEmail());
+        return new TokenInfo(newAccessToken, newRefreshToken);
+    }
+
+    public Authentication getAuthentication(String token) {
+        log.debug("토큰으로부터 인증 정보 추출 중");
+        Claims claims = Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get("auth").toString().split(","))
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+
+        String username = claims.getSubject();
+        log.info("사용자에 대한 인증 정보가 추출되었습니다: {}", username);
+
+        return new UsernamePasswordAuthenticationToken(username, token, authorities);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser().verifyWith(key).build().parseSignedClaims(token);
+            log.debug("토큰이 성공적으로 검증되었습니다");
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            log.error("유효하지 않은 JWT 토큰: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    // TokenInfo DTO
+    @Getter
+    @AllArgsConstructor
+    public static class TokenInfo {
+        private String accessToken;
+        private String refreshToken;
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/auth/repository/RefreshTokenRepository.java
+++ b/back/moya/src/main/java/com/study/moya/auth/repository/RefreshTokenRepository.java
@@ -15,4 +15,8 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     @Modifying
     @Query("DELETE FROM RefreshToken r WHERE r.memberEmail = :memberEmail")
     void deleteByMemberEmail(@Param("memberEmail") String memberEmail);
+
+    @Modifying
+    @Query("DELETE FROM RefreshToken r WHERE r.token = :token")
+    void deleteByToken(@Param("token") String token);
 }

--- a/back/moya/src/main/java/com/study/moya/auth/repository/RefreshTokenRepository.java
+++ b/back/moya/src/main/java/com/study/moya/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,18 @@
+package com.study.moya.auth.repository;
+
+import com.study.moya.auth.domain.RefreshToken;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByToken(String token);
+    Optional<RefreshToken> findByMemberEmail(String memberEmail);
+    @Modifying
+    @Query("DELETE FROM RefreshToken r WHERE r.memberEmail = :memberEmail")
+    void deleteByMemberEmail(@Param("memberEmail") String memberEmail);
+}

--- a/back/moya/src/main/java/com/study/moya/auth/service/AuthService.java
+++ b/back/moya/src/main/java/com/study/moya/auth/service/AuthService.java
@@ -1,19 +1,23 @@
 package com.study.moya.auth.service;
 
+import com.study.moya.auth.dto.LoginRequest;
 import com.study.moya.auth.dto.UserInfoResponse;
 import com.study.moya.auth.jwt.JwtTokenProvider;
-import com.study.moya.auth.dto.LoginRequest;
 import com.study.moya.auth.jwt.JwtTokenProvider.TokenInfo;
 import com.study.moya.auth.repository.RefreshTokenRepository;
+import com.study.moya.member.constants.MemberErrorCode;
 import com.study.moya.member.domain.Member;
+import com.study.moya.member.exception.MemberException;
 import com.study.moya.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -25,17 +29,41 @@ public class AuthService {
     private final MemberRepository memberRepository;
     private final JwtTokenProvider tokenProvider;
 
+    @Transactional
     public TokenInfo authenticateUser(LoginRequest loginRequest) {
         log.info("인증 프로세스 시작 - 이메일: {}", loginRequest.email());
 
-        Authentication authentication = authenticationManager.authenticate(
-                new UsernamePasswordAuthenticationToken(loginRequest.email(), loginRequest.password())
-        );
+        // 1. 먼저 회원 존재 여부와 로그인 가능 상태 확인
+        Member member = memberRepository.findByEmail(loginRequest.email())
+                .orElseThrow(() -> new BadCredentialsException("Invalid credentials"));
+
+        if (!member.isLoginable()) {
+            log.warn("로그인 불가능한 상태의 계정 접근 시도 - 이메일: {}, 상태: {}",
+                    loginRequest.email(), member.getStatus());
+            throw new MemberException(MemberErrorCode.MEMBER_NOT_LOGINABLE);
+        }
+
+        // 2. Spring Security 인증 처리
+        Authentication authentication;
+        try {
+            authentication = authenticationManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(loginRequest.email(), loginRequest.password())
+            );
+        } catch (BadCredentialsException e) {
+            log.warn("잘못된 인증 정보 - 이메일: {}", loginRequest.email());
+            throw e;
+        }
         log.info("인증 매니저 인증 완료");
 
+        // 3. 로그인 성공 시 회원 정보 업데이트
+        member.updateLoginInfo();
+        log.info("회원 로그인 정보 업데이트 완료");
+
+        // 4. Security Context에 인증 정보 저장
         SecurityContextHolder.getContext().setAuthentication(authentication);
         log.info("SecurityContext에 인증 정보 저장 완료");
 
+        // 5. JWT 토큰 생성
         TokenInfo tokenInfo = tokenProvider.createToken(authentication);
         log.info("JWT 토큰 생성 완료");
 

--- a/back/moya/src/main/java/com/study/moya/auth/service/AuthService.java
+++ b/back/moya/src/main/java/com/study/moya/auth/service/AuthService.java
@@ -4,6 +4,7 @@ import com.study.moya.auth.dto.UserInfoResponse;
 import com.study.moya.auth.jwt.JwtTokenProvider;
 import com.study.moya.auth.dto.LoginRequest;
 import com.study.moya.auth.jwt.JwtTokenProvider.TokenInfo;
+import com.study.moya.auth.repository.RefreshTokenRepository;
 import com.study.moya.member.domain.Member;
 import com.study.moya.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class AuthService {
 
+    private final RefreshTokenRepository refreshTokenRepository;
     private final AuthenticationManager authenticationManager;
     private final MemberRepository memberRepository;
     private final JwtTokenProvider tokenProvider;
@@ -55,5 +57,11 @@ public class AuthService {
                 member.getEmail(),
                 member.getRoles()
         );
+    }
+
+    public void invalidateRefreshToken(String refreshToken) {
+        // 리프레시 토큰을 DB에서 찾아서 삭제
+        refreshTokenRepository.deleteByToken(refreshToken);
+        log.info("리프레시 토큰 삭제 완료");
     }
 }

--- a/back/moya/src/main/java/com/study/moya/auth/service/AuthService.java
+++ b/back/moya/src/main/java/com/study/moya/auth/service/AuthService.java
@@ -1,0 +1,59 @@
+package com.study.moya.auth.service;
+
+import com.study.moya.auth.dto.UserInfoResponse;
+import com.study.moya.auth.jwt.JwtTokenProvider;
+import com.study.moya.auth.dto.LoginRequest;
+import com.study.moya.auth.jwt.JwtTokenProvider.TokenInfo;
+import com.study.moya.member.domain.Member;
+import com.study.moya.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final AuthenticationManager authenticationManager;
+    private final MemberRepository memberRepository;
+    private final JwtTokenProvider tokenProvider;
+
+    public TokenInfo authenticateUser(LoginRequest loginRequest) {
+        log.info("인증 프로세스 시작 - 이메일: {}", loginRequest.email());
+
+        Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(loginRequest.email(), loginRequest.password())
+        );
+        log.info("인증 매니저 인증 완료");
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        log.info("SecurityContext에 인증 정보 저장 완료");
+
+        TokenInfo tokenInfo = tokenProvider.createToken(authentication);
+        log.info("JWT 토큰 생성 완료");
+
+        return tokenInfo;
+    }
+
+    public TokenInfo refreshToken(String refreshToken) {
+        log.info("토큰 갱신 프로세스 시작");
+        return tokenProvider.refreshAccessToken(refreshToken);
+    }
+
+    public UserInfoResponse getUserInfo(Authentication authentication) {
+        String email = authentication.getName();
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("Member not found"));
+
+        return new UserInfoResponse(
+                member.getNickname(),
+                member.getEmail(),
+                member.getRoles()
+        );
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/global/config/SecurityConfig.java
+++ b/back/moya/src/main/java/com/study/moya/global/config/SecurityConfig.java
@@ -68,13 +68,6 @@ public class SecurityConfig {
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
-                .logout(logout -> logout
-                        .logoutUrl("/api/auth/logout")
-                        .logoutSuccessHandler(new HttpStatusReturningLogoutSuccessHandler(HttpStatus.OK))
-                        .deleteCookies("refresh_token")
-                        .invalidateHttpSession(true)
-                        .clearAuthentication(true)
-                )
                 .addFilterBefore(new JwtAuthenticationFilter(authenticationManager(authenticationConfiguration),
                                 jwtTokenProvider),
                         UsernamePasswordAuthenticationFilter.class)

--- a/back/moya/src/main/java/com/study/moya/global/config/SecurityConfig.java
+++ b/back/moya/src/main/java/com/study/moya/global/config/SecurityConfig.java
@@ -1,0 +1,114 @@
+package com.study.moya.global.config;
+
+import com.study.moya.auth.jwt.JwtAuthorizationFilter;
+import com.study.moya.auth.jwt.JwtTokenProvider;
+import com.study.moya.auth.jwt.JwtAuthenticationFilter;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.HttpStatusReturningLogoutSuccessHandler;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Slf4j
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final AuthenticationConfiguration authenticationConfiguration;
+
+//    @Value("${cors.allowed-origins}")
+//    private List<String> allowedOrigins;
+//
+//    @Value("${cors.allowed-methods}")
+//    private List<String> allowedMethods;
+//
+//    @Value("${cors.allowed-headers}")
+//    private List<String> allowedHeaders;
+//
+//    @Value("${cors.allow-credentials}")
+//    private boolean allowCredentials;
+//
+//    @Value("${cors.max-age}")
+//    private long maxAge;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(authz -> authz
+                        .requestMatchers("/api/auth/**", "/css/**", "/js/**", "/*.ico", "/dashboard",
+                                "/webjars/**", "/swagger-ui.html", "/swagger-ui/**", "/actuator/**",
+                                "/mermaid/**", "/api/mermaid/**",
+                                "/api-docs/**", "/v3/api-docs/**", "/result", "/",
+                                "/video", "/signal", "/vid", // 추가된 부분
+                                "/error", "/roadmap/**", // 에러 페이지도 허용
+                                "/whiteboard"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .logout(logout -> logout
+                        .logoutUrl("/api/auth/logout")
+                        .logoutSuccessHandler(new HttpStatusReturningLogoutSuccessHandler(HttpStatus.OK))
+                        .deleteCookies("refresh_token")
+                        .invalidateHttpSession(true)
+                        .clearAuthentication(true)
+                )
+                .addFilterBefore(new JwtAuthenticationFilter(authenticationManager(authenticationConfiguration),
+                                jwtTokenProvider),
+                        UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtAuthorizationFilter(jwtTokenProvider),
+                        UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(
+                List.of("http://192.168.0.26:3090", "http://localhost:3000", "http://localhost:3090"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+        configuration.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration)
+            throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/back/moya/src/main/java/com/study/moya/member/constants/MemberErrorCode.java
+++ b/back/moya/src/main/java/com/study/moya/member/constants/MemberErrorCode.java
@@ -12,7 +12,8 @@ public enum MemberErrorCode {
     MEMBER_NOT_MODIFIABLE("회원 정보를 수정할 수 없습니다. %s"),
     MEMBER_BLOCKED("차단된 회원입니다."),
     MEMBER_WITHDRAWN("탈퇴한 회원입니다."),
-    DUPLICATE_NICKNAME("이미 사용 중인 닉네임입니다.");
+    DUPLICATE_NICKNAME("이미 사용 중인 닉네임입니다."),
+    MEMBER_NOT_LOGINABLE("로그인 할 수 없는 사용자입니다.");
 
     private final String messageTemplate;
 

--- a/back/moya/src/main/java/com/study/moya/member/repository/MemberRepository.java
+++ b/back/moya/src/main/java/com/study/moya/member/repository/MemberRepository.java
@@ -1,0 +1,14 @@
+package com.study.moya.member.repository;
+
+import com.study.moya.member.domain.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmail(String email);
+
+    boolean existsByEmail(String email);
+}

--- a/back/moya/src/main/java/com/study/moya/member/service/MemberService.java
+++ b/back/moya/src/main/java/com/study/moya/member/service/MemberService.java
@@ -1,0 +1,113 @@
+package com.study.moya.member.service;
+
+import com.study.moya.auth.dto.SignupRequest;
+import com.study.moya.auth.exception.EmailAlreadyExistsException;
+import com.study.moya.auth.exception.UserNotFoundException;
+import com.study.moya.member.domain.Member;
+import com.study.moya.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class MemberService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public void registerNewUser(SignupRequest signUpRequest) {
+        log.info("새 사용자 등록 시작 - 이메일: {}, 닉네임: {}", signUpRequest.email(), signUpRequest.nickname());
+        try {
+            validateEmailNotExists(signUpRequest.email());
+            log.info("이메일 중복 검사 완료 - 이메일: {}", signUpRequest.email());
+
+            Member member = createMemberFromRequest(signUpRequest);
+            log.info("회원 엔티티 생성 완료 - 이메일: {}", member.getEmail());
+
+            Member savedMember = memberRepository.save(member);
+            log.info("회원 저장 완료 - 이메일: {}, ID: {}", savedMember.getEmail(), savedMember.getId());
+        } catch (Exception e) {
+            log.error("회원 가입 처리 중 오류 발생 - 이메일: {}, 오류: {}", signUpRequest.email(), e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    private void validateEmailNotExists(String email) {
+        log.debug("이메일 중복 검사 시작 - 이메일: {}", email);
+        if (memberRepository.existsByEmail(email)) {
+            log.warn("이메일 중복 발견 - 이메일: {}", email);
+            throw new EmailAlreadyExistsException(email);
+        }
+        log.debug("이메일 중복 검사 통과 - 이메일: {}", email);
+    }
+
+    private Member createMemberFromRequest(SignupRequest signUpRequest) {
+        log.debug("회원 엔티티 생성 시작 - 이메일: {}", signUpRequest.email());
+        String encodedPassword = passwordEncoder.encode(signUpRequest.password());
+        log.debug("비밀번호 암호화 완료 - 이메일: {}", signUpRequest.email());
+
+        Member member = Member.builder()
+                .email(signUpRequest.email())
+                .password(encodedPassword)
+                .nickname(signUpRequest.nickname())
+                .providerId(signUpRequest.providerId())
+                .profileImageUrl(signUpRequest.profileImageUrl())
+                .termsAgreed(signUpRequest.termsAgreed())
+                .privacyPolicyAgreed(signUpRequest.privacyPolicyAgreed())
+                .marketingAgreed(signUpRequest.marketingAgreed())
+                .build();
+
+        log.debug("회원 엔티티 생성 완료 - 이메일: {}, 닉네임: {}", member.getEmail(), member.getNickname());
+        return member;
+    }
+
+    @Transactional(readOnly = true)
+    public Member findByEmail(String email) {
+        log.debug("이메일로 회원 조회 시작 - 이메일: {}", email);
+        try {
+            Member member = memberRepository.findByEmail(email)
+                    .orElseThrow(() -> {
+                        log.error("회원을 찾을 수 없음 - 이메일: {}", email);
+                        return new UserNotFoundException(email);
+                    });
+            log.debug("회원 조회 완료 - 이메일: {}, ID: {}", email, member.getId());
+            return member;
+        } catch (Exception e) {
+            log.error("회원 조회 중 오류 발생 - 이메일: {}, 오류: {}", email, e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public boolean existsByEmail(String email) {
+        log.debug("이메일 존재 여부 확인 시작 - 이메일: {}", email);
+        boolean exists = memberRepository.existsByEmail(email);
+        log.debug("이메일 존재 여부 확인 완료 - 이메일: {}, 존재여부: {}", email, exists);
+        return exists;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserDetails loadUserByUsername(String email) {
+        log.info("사용자 정보 로딩 시작 - 이메일: {}", email);
+        try {
+            UserDetails userDetails = memberRepository.findByEmail(email)
+                    .orElseThrow(() -> {
+                        log.error("사용자를 찾을 수 없음 - 이메일: {}", email);
+                        return new UserNotFoundException(email);
+                    });
+            log.info("사용자 정보 로딩 완료 - 이메일: {}", email);
+            return userDetails;
+        } catch (Exception e) {
+            log.error("사용자 정보 로딩 중 오류 발생 - 이메일: {}, 오류: {}", email, e.getMessage(), e);
+            throw e;
+        }
+    }
+}

--- a/back/moya/src/test/java/com/study/moya/auth/AuthControllerLogoutTest.java
+++ b/back/moya/src/test/java/com/study/moya/auth/AuthControllerLogoutTest.java
@@ -1,0 +1,156 @@
+package com.study.moya.auth;
+
+
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.hibernate.validator.internal.util.Contracts.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.study.moya.auth.dto.LoginRequest;
+import com.study.moya.auth.jwt.JwtTokenProvider.TokenInfo;
+import com.study.moya.auth.service.AuthService;
+import com.study.moya.member.repository.MemberRepository;
+import jakarta.servlet.http.Cookie;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class AuthControllerLogoutTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @MockBean
+    private AuthService authService;
+
+    private static final String TEST_EMAIL = "test@example.com";
+    private static final String TEST_PASSWORD = "Password123!";
+
+    @BeforeEach
+    void setUp() {
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("로그아웃 성공 테스트")
+    void logout_Success() throws Exception {
+        // Given
+        // 먼저 로그인을 수행하여 쿠키 설정
+        TokenInfo tokenInfo = new TokenInfo("test-access-token", "test-refresh-token");
+        when(authService.authenticateUser(any(LoginRequest.class))).thenReturn(tokenInfo);
+
+        LoginRequest loginRequest = new LoginRequest(TEST_EMAIL, TEST_PASSWORD);
+
+        // 로그인 수행
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andDo(print()) // 로그인 응답 출력
+                .andReturn();
+
+        // 로그인 응답에서 쿠키 확인
+        Cookie[] loginCookies = loginResult.getResponse().getCookies();
+        //log.info("Login response cookies: {}", Arrays.toString(loginCookies));
+
+        // When & Then
+        // 로그아웃 수행 및 검증
+        MvcResult logoutResult = mockMvc.perform(post("/api/auth/logout")
+                        .cookie(loginCookies)) // 로그인에서 받은 쿠키 포함
+                .andDo(print()) // 로그아웃 응답 출력
+                .andExpect(status().isOk())
+                .andExpect(result -> {
+                    Cookie[] cookies = result.getResponse().getCookies();
+                    //log.info("Logout response cookies: {}", Arrays.toString(cookies));
+
+                    // 쿠키가 존재하는지 확인
+                    assertTrue(cookies != null && cookies.length > 0, "응답에 쿠키가 없습니다.");
+
+                    // refresh_token 쿠키를 찾아서 검증
+                    Optional<Cookie> refreshTokenCookie = Arrays.stream(cookies)
+                            .filter(cookie -> "refresh_token".equals(cookie.getName()))
+                            .findFirst();
+
+                    assertTrue(refreshTokenCookie.isPresent(),
+                            "refresh_token 쿠키가 없습니다. 존재하는 쿠키: " +
+                                    Arrays.toString(cookies));
+
+                    assertEquals(0, refreshTokenCookie.get().getMaxAge(),
+                            "쿠키 만료 시간이 0이 아닙니다.");
+                })
+                .andReturn();
+
+        // 추가 로깅
+//        log.info("Login Request: {}", objectMapper.writeValueAsString(loginRequest));
+//        log.info("Login Response Status: {}", loginResult.getResponse().getStatus());
+//        log.info("Logout Response Status: {}", logoutResult.getResponse().getStatus());
+//        log.info("Logout Response Headers: {}", logoutResult.getResponse().getHeaderNames());
+    }
+
+    @Test
+    @DisplayName("로그아웃 요청 시 모든 인증 관련 쿠키가 제거되는지 확인")
+    void logout_RemovesAllAuthCookies() throws Exception {
+        // Given
+        Cookie refreshTokenCookie = new Cookie("refresh_token", "test-refresh-token");
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setHttpOnly(true);
+
+        Cookie jwtCookie = new Cookie("jwt", "test-jwt-token");
+        jwtCookie.setPath("/");
+        jwtCookie.setHttpOnly(true);
+
+        // When & Then
+        mockMvc.perform(post("/api/auth/logout")
+                        .cookie(refreshTokenCookie, jwtCookie))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(result -> {
+                    Cookie[] responseCookies = result.getResponse().getCookies();
+                    assertNotNull(responseCookies, "응답 쿠키가 null입니다");
+
+                    List<Cookie> expiredCookies = Arrays.stream(responseCookies)
+                            .filter(cookie -> cookie.getMaxAge() == 0)
+                            .collect(Collectors.toList());
+
+
+
+                            expiredCookies.stream()
+                                    .map(Cookie::getName)
+                                    .collect(Collectors.joining(", "));
+
+                    assertTrue(expiredCookies.stream()
+                                    .anyMatch(cookie -> "refresh_token".equals(cookie.getName())),
+                            "refresh_token 쿠키가 만료되지 않았습니다");
+                });
+    }
+}

--- a/back/moya/src/test/java/com/study/moya/auth/AuthControllerTest.java
+++ b/back/moya/src/test/java/com/study/moya/auth/AuthControllerTest.java
@@ -1,0 +1,143 @@
+package com.study.moya.auth;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.study.moya.auth.dto.LoginRequest;
+import com.study.moya.auth.dto.SignupRequest;
+import com.study.moya.auth.jwt.JwtTokenProvider;
+import com.study.moya.auth.jwt.JwtTokenProvider.TokenInfo;
+import com.study.moya.auth.service.AuthService;
+import com.study.moya.member.repository.MemberRepository;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockBean
+    private AuthService authService;
+
+    private SignupRequest validSignupRequest;
+    private LoginRequest validLoginRequest;
+
+    @BeforeEach
+    void setUp() {
+        memberRepository.deleteAll();
+
+        validSignupRequest = new SignupRequest(
+                "test@example.com",
+                "Password123!",
+                "testUser",
+                null,
+                "local",
+                true,
+                true,
+                false
+        );
+
+        validLoginRequest = new LoginRequest(
+                "test@example.com",
+                "Password123!"
+        );
+    }
+
+    @Test
+    @DisplayName("회원가입 성공 테스트")
+    void registerUser_Success() throws Exception {
+        mockMvc.perform(post("/api/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(validSignupRequest)))
+                .andExpect(status().isOk())
+                .andExpect(content().string("회원가입이 성공적으로 이루어졌습니다"));
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - 이메일 형식 불일치")
+    void registerUser_InvalidEmail() throws Exception {
+        SignupRequest invalidRequest = new SignupRequest(
+                "invalid-email",
+                "Password123!",
+                "testUser",
+                null,
+                "local",
+                true,
+                true,
+                false
+        );
+
+        mockMvc.perform(post("/api/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequest)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("로그인 성공 테스트")
+    void login_Success() throws Exception {
+        TokenInfo tokenInfo = new TokenInfo("access-token", "refresh-token");
+        when(authService.authenticateUser(any(LoginRequest.class))).thenReturn(tokenInfo);
+
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(validLoginRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").exists())
+                .andExpect(cookie().exists("refresh_token"));
+    }
+
+    @Test
+    @DisplayName("토큰 갱신 성공 테스트")
+    void refreshToken_Success() throws Exception {
+        TokenInfo tokenInfo = new TokenInfo("new-access-token", "new-refresh-token");
+        when(authService.refreshToken(anyString())).thenReturn(tokenInfo);
+
+        Cookie refreshTokenCookie = new Cookie("refresh_token", "valid-refresh-token");
+
+        mockMvc.perform(post("/api/auth/refresh")
+                        .cookie(refreshTokenCookie))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").exists())
+                .andExpect(cookie().exists("refresh_token"));
+    }
+
+    @Test
+    @DisplayName("로그아웃 성공 테스트")
+    void logout_Success() throws Exception {
+        mockMvc.perform(post("/api/auth/logout"))
+                .andExpect(status().isOk())
+                .andExpect(cookie().maxAge("refresh_token", 0));
+    }
+}


### PR DESCRIPTION
# JWT 인증 시스템 구현

## 🔍 PR 개요
JWT 기반의 인증/인가 시스템을 구현하였습니다. Access Token과 Refresh Token을 활용한 보안성 높은 인증 체계와 함께, 회원 상태에 따른 접근 제어, 토큰 갱신, 로그아웃 등의 기능을 포함하고 있습니다.

## 📝 변경사항
### JWT 인증/인가 필터 구현
- `JwtAuthenticationFilter`: 로그인 요청 처리 및 토큰 발급
- `JwtAuthorizationFilter`: 요청별 토큰 검증 및 인증 처리
- XSS, CSRF 등 보안 헤더 설정

### 토큰 관리 시스템 구현
- `JwtTokenProvider`: 토큰 생성, 검증, 갱신 로직
- Access Token은 Authorization 헤더로 전달
- Refresh Token은 HttpOnly + Secure 쿠키로 안전하게 관리
  
### RefreshToken 도메인 구현
- 토큰 만료 시간 관리
- 회원 이메일 기반 토큰 관리
- 인덱스 설정으로 조회 성능 최적화

### AuthService 구현
- 회원 상태 검증을 통한 안전한 로그인 처리
- 토큰 갱신 및 로그아웃 처리
- 회원 정보 조회 기능

## 🔗 관련 이슈
- Close #12  JWT인증/인가 구현

## ✅ 체크리스트
### 로컬 테스트
- [x] 토큰 생성, 검증, 갱신 플로우 테스트 완료
- [x] 로그인/로그아웃 기능 테스트 완료
- [x] 보안 설정 테스트 완료

### JPA 성능 최적화
- [x] RefreshToken 엔티티에 적절한 인덱스 추가
  - memberEmail 조회용 인덱스
  - token 유니크 인덱스
- [x] 토큰 조회 시 인덱스 활용

### 캐시 정책
- [ ] Redis 캐시 적용 필요성 검토
  - 현재는 캐시 적용 대상 아님
  - 추후 토큰 블랙리스트 관리를 위한 Redis 도입 고려 필요

### DB 스키마 변경
- [x] RefreshToken 테이블 생성
```sql
CREATE TABLE refresh_token (
    id BIGINT PRIMARY KEY AUTO_INCREMENT,
    token VARCHAR(255) NOT NULL UNIQUE,
    member_email VARCHAR(255) NOT NULL,
    expiry_date DATETIME NOT NULL,
    INDEX idx_member_email (member_email),
    INDEX idx_token (token)
);
```

### API 문서화
- [x] AuthController에 @Tag 추가로 API 문서화 완료
- [x] 각 엔드포인트 설명 추가

## 🚨 주의사항
### 1. 보안 설정
- JWT 시크릿 키 설정 필요 (`application.yml`의 `jwt.secret`)
- Access Token과 Refresh Token의 만료 시간 설정 필요
- 운영 환경에서 HTTPS 필수 적용 (Secure 쿠키 사용)

### 2. 토큰 관리
- Refresh Token은 데이터베이스에서 관리됨
- 만료된 토큰은 자동으로 검증 및 갱신 처리
- 로그아웃 시 Refresh Token 무효화 처리

### 3. 에러 처리
- 토큰 관련 예외는 적절한 HTTP 상태 코드로 응답
- 보안 관련 에러는 최소한의 정보만 클라이언트에 노출

