### PR TITLE
Kan 66 chat test

### DIFF
--- a/back/moya/src/main/java/com/study/moya/chat/text/controller/FileController.java
+++ b/back/moya/src/main/java/com/study/moya/chat/text/controller/FileController.java
@@ -1,0 +1,55 @@
+package com.study.moya.chat.text.controller;
+
+import com.study.moya.chat.text.service.FileService;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@RestController
+@RequestMapping("/files")
+public class FileController {
+
+    private final FileService fileService;
+
+    public FileController(FileService fileService) {
+        this.fileService = fileService;
+    }
+
+    @GetMapping("/{roomId}/{fileName:.+}")
+    public ResponseEntity<Resource> getFile(
+            @PathVariable String roomId,
+            @PathVariable String fileName) {
+        try {
+            Resource resource = fileService.loadFileAsResource(roomId, fileName);
+
+            String contentType = Files.probeContentType(resource.getFile().toPath());
+            if(contentType == null) {
+                contentType = "application/octet-stream";
+            }
+
+            return ResponseEntity.ok()
+                    .contentType(MediaType.parseMediaType(contentType))
+                    .body(resource);
+        } catch (FileNotFoundException ex) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage());
+        } catch (IOException ex) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "파일을 로드하는 중 오류가 발생했습니다.");
+        }
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/chat/text/controller/FileUploadController.java
+++ b/back/moya/src/main/java/com/study/moya/chat/text/controller/FileUploadController.java
@@ -24,7 +24,6 @@ public class FileUploadController {
 
     private final FileService fileService;
     private final SimpMessagingTemplate messagingTemplate;
-    private final ChatService chatService;
 
     @PostMapping("/{roomId}/upload")
     public ResponseEntity<FileUploadResponse> uploadFile (

--- a/back/moya/src/main/java/com/study/moya/chat/text/controller/FileUploadController.java
+++ b/back/moya/src/main/java/com/study/moya/chat/text/controller/FileUploadController.java
@@ -1,0 +1,59 @@
+package com.study.moya.chat.text.controller;
+
+import com.study.moya.chat.text.dto.chat.FileChatDTO;
+import com.study.moya.chat.text.dto.chat.MessageType;
+import com.study.moya.chat.text.dto.chat.request.FileUploadRequest;
+import com.study.moya.chat.text.dto.chat.request.FileUploadResponse;
+import com.study.moya.chat.text.service.ChatService;
+import com.study.moya.chat.text.service.FileService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/ws/chat/files")
+public class FileUploadController {
+
+    private final FileService fileService;
+    private final SimpMessagingTemplate messagingTemplate;
+    private final ChatService chatService;
+
+    @PostMapping("/{roomId}/upload")
+    public ResponseEntity<FileUploadResponse> uploadFile (
+            @PathVariable String roomId,
+            @ModelAttribute FileUploadRequest requestDTO) {
+        try {
+            String sender = requestDTO.sender();
+            MultipartFile file = requestDTO.multipartFile();
+
+            String fileUrl = fileService.storeFile(roomId, file);
+
+            FileChatDTO fileMessage = new FileChatDTO(
+                    MessageType.CHAT,//File 타입 추가
+                    roomId,
+                    sender,
+                    "파일을 전송했습니다.",
+                    fileUrl,
+                    LocalDateTime.now()
+            );//도착하는 시간기준으로 메세지 시간 설정 (고민하기)
+
+            messagingTemplate.convertAndSend("/sub/chat/room/" + roomId, fileMessage);
+
+            return ResponseEntity.status(HttpStatus.CREATED)
+                    .body(new FileUploadResponse(fileUrl, "파일 업로드 성공"));
+        } catch (Exception e) {
+            //예외 구체화
+            log.error("파일 업로드 실패 : {} ", e.getMessage());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new FileUploadResponse(null, "파일 업로드 실패"));
+        }
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/chat/text/dto/chat/FileChatDTO.java
+++ b/back/moya/src/main/java/com/study/moya/chat/text/dto/chat/FileChatDTO.java
@@ -1,0 +1,13 @@
+package com.study.moya.chat.text.dto.chat;
+
+import java.time.LocalDateTime;
+
+public record FileChatDTO(
+        MessageType type,
+        String roomId,
+        String sender,
+        String message,
+        String fileUrl,
+        LocalDateTime timestamp
+) {
+}

--- a/back/moya/src/main/java/com/study/moya/chat/text/dto/chat/request/FileUploadRequest.java
+++ b/back/moya/src/main/java/com/study/moya/chat/text/dto/chat/request/FileUploadRequest.java
@@ -1,0 +1,9 @@
+package com.study.moya.chat.text.dto.chat.request;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public record FileUploadRequest(
+        String sender,
+        MultipartFile multipartFile
+) {
+}

--- a/back/moya/src/main/java/com/study/moya/chat/text/dto/chat/request/FileUploadResponse.java
+++ b/back/moya/src/main/java/com/study/moya/chat/text/dto/chat/request/FileUploadResponse.java
@@ -1,0 +1,7 @@
+package com.study.moya.chat.text.dto.chat.request;
+
+public record FileUploadResponse(
+        String fileUrl,
+        String message
+) {
+}

--- a/back/moya/src/main/java/com/study/moya/chat/text/service/FileService.java
+++ b/back/moya/src/main/java/com/study/moya/chat/text/service/FileService.java
@@ -1,0 +1,99 @@
+package com.study.moya.chat.text.service;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.file.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class FileService {
+
+    private final Path fileStorageLocation;
+    private static final List<String> ALLOWED_EXTENSIONS = Arrays.asList(".png", ".jpg", ".jpeg", ".gif", ".mp4", ".mp3", ".wav", ".ogg");
+
+    public FileService(@Value("${file.upload-dir}") String uploadDir) {
+        this.fileStorageLocation = Paths.get(uploadDir).toAbsolutePath().normalize();
+    }
+
+    @PostConstruct
+    public void init() {
+        try {
+            Files.createDirectories(this.fileStorageLocation);
+        } catch (IOException ex) {
+            throw new RuntimeException("파일 저장 디렉토리를 생성할 수 없습니다: " + ex.getMessage());
+        }
+    }
+
+    public String storeFile(String roomId, MultipartFile file) {
+        String originalFileName = StringUtils.cleanPath(file.getOriginalFilename());
+
+        try {
+            // 파일 이름에 '..'이 포함되어 있는지 확인하여 경로 트래버설 공격 방지
+            if(originalFileName.contains("..")) {
+                throw new IOException("잘못된 파일 경로.");
+            }
+
+            // 파일 확장자 추출 및 검증
+            String fileExtension = getFileExtension(originalFileName);
+            if (!isAllowedExtension(fileExtension)) {
+                throw new IOException("허용되지 않는 파일 형식입니다.");
+            }
+
+            // 고유 파일 이름 생성
+            String fileName = UUID.randomUUID().toString() + fileExtension;
+
+            // 방별 디렉토리 생성
+            Path roomDir = this.fileStorageLocation.resolve(roomId);
+            if (!Files.exists(roomDir)) {
+                Files.createDirectories(roomDir);
+            }
+
+            // 파일 저장 경로
+            Path targetLocation = roomDir.resolve(fileName);
+
+            // 파일 저장
+            Files.copy(file.getInputStream(), targetLocation, StandardCopyOption.REPLACE_EXISTING);
+
+            //파일 경로에 대한 DB 저장 고민
+
+            // 방별 파일 URL 생성
+            String fileUrl = "/files/" + roomId + "/" + fileName;
+            return fileUrl;
+
+        } catch (IOException ex) {
+            throw new RuntimeException("파일 저장에 실패했습니다: " + ex.getMessage());
+        }
+    }
+
+    private String getFileExtension(String fileName) {
+        int dotIndex = fileName.lastIndexOf('.');
+        return (dotIndex > 0) ? fileName.substring(dotIndex).toLowerCase() : "";
+    }
+
+    private boolean isAllowedExtension(String extension) {
+        return ALLOWED_EXTENSIONS.contains(extension);
+    }
+
+    // FileService에 파일 제공 로직 추가
+    public Resource loadFileAsResource(String roomId, String fileName) throws MalformedURLException, FileNotFoundException {
+        Path filePath = this.fileStorageLocation.resolve(roomId).resolve(fileName).normalize();
+        Resource resource = new UrlResource(filePath.toUri());
+
+        if(resource.exists() && resource.isReadable()) {
+            return resource;
+        } else {
+            throw new FileNotFoundException("파일을 찾을 수 없습니다: " + fileName);
+        }
+    }
+}


### PR DESCRIPTION
# {기능 이름}

## 🔍 PR 개요
실시간 채팅에서 파일 업로드 및 다운로드를 처리하기 위한 REST API와 WebSocket 메시지 전송 로직을 추가 구현했습니다.

## 📝 변경사항
<!--주요 변경사항을 항목별로 설명해주세요.-->
### 주요 기능 1: 파일 업로드 API 구현
	•	파일을 방별 디렉토리에 저장하고, 저장된 파일의 URL을 생성해 반환하는 API 추가
	•	FileUploadRequest DTO를 통해 업로더와 파일 데이터를 받도록 구성
	•	업로드 성공 시 WebSocket을 통해 채팅 메시지와 파일 URL을 방 내 사용자들에게 브로드캐스팅

### 주요 기능 2: 파일 다운로드 API 구현
	•	방별 디렉토리에 저장된 파일을 HTTP 응답으로 제공하는 API 추가
	•	파일 확장자 및 MIME 타입에 따라 Content-Type을 동적으로 설정
	•	파일이 존재하지 않거나 읽기 불가능한 경우 적절한 예외 처리 추가
### 주요 기능 3: 실시간 파일 전송 메시지
	•	파일 업로드 후 WebSocket 메시지를 통해 FileChatDTO를 방 내 모든 사용자에게 전송
	•	메시지 타입은 MessageType.CHAT로 설정하며, 파일 URL과 업로더 정보를 포함
	•	메시지 전송 시 파일 업로드 시간을 기준으로 LocalDateTime 값 설정

## 🔗 관련 이슈
<!--관련된 이슈를 연결해주세요.-->
- Close #{이슈번호} {이슈내용}

## ✅ 체크리스트
<!--각 항목을 체크하고 필요한 내용을 추가해주세요.-->
### 로컬 테스트
- [ ] 기능 1 테스트 완료
- [ ] 기능 2 테스트 완료
- [ ] 기능 3 테스트 완료

### JPA 성능 최적화
	•	파일 메타데이터를 저장하기 위한 JPA 엔티티 설계 필요 (후속 작업)
	•	DB 접근 최소화를 위한 캐싱 여부 검토


### 캐시 정책
	•	캐시 적용 필요성 검토
	•	파일 URL은 정적 리소스로 간주하므로 캐싱 적용 필요 없음

### DB 스키마 변경
- [ ] 테이블 생성/수정
```sql
-- SQL 구문 작성
```

### API 문서화
- [ ] Controller에 @Tag 추가
- [ ] API 설명 추가

## 🚨 주의사항
### 1. 설정 관련
application.properties 또는 application.yml에 파일 저장 경로 설정 필요(공유 예정)