### PR TITLE
KAN-107 feat. 로그아웃 기능 설정 + OAuth 기능 일부 수정 (callbackUri)

### DIFF
--- a/back/moya/src/main/java/com/study/moya/Oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/back/moya/src/main/java/com/study/moya/Oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -78,9 +78,8 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         addTokenCookie(response, loginResponse.getAccessToken());
 
         //API 응답 설정
-        response.setContentType("application/json");
-        response.setCharacterEncoding("UTF-8");
-        objectMapper.writeValue(response.getWriter(), loginResponse);
+        String redirectUrl = buildRedirectUri(loginResponse);
+        response.sendRedirect(redirectUrl);
     }
 
     private void addTokenCookie(HttpServletResponse response, String token) {
@@ -92,7 +91,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
     private String buildRedirectUri(OauthLoginResponse loginResponse) throws JsonProcessingException {
         return UriComponentsBuilder
-                .fromUriString("https://moyastudy.com")
+                .fromUriString("http://localhost:3000/api/auth/oauth/callback")
                 .queryParam("data", URLEncoder.encode(
                         objectMapper.writeValueAsString(loginResponse),
                         StandardCharsets.UTF_8

--- a/back/moya/src/main/java/com/study/moya/auth/dto/LogoutRequest.java
+++ b/back/moya/src/main/java/com/study/moya/auth/dto/LogoutRequest.java
@@ -1,0 +1,24 @@
+package com.study.moya.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+public class LogoutRequest {
+    private final String email;
+    private final String accessToken;
+    private final String refreshToken;
+
+    // toString 메서드 추가 (디버깅용)
+    @Override
+    public String toString() {
+        return "LogoutRequest{" +
+                "email='" + email + '\'' +
+                ", accessToken='" + (accessToken != null ? "[PROTECTED]" : "null") + '\'' +
+                ", refreshToken='" + (refreshToken != null ? "[PROTECTED]" : "null") + '\'' +
+                '}';
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/auth/dto/LogoutResponse.java
+++ b/back/moya/src/main/java/com/study/moya/auth/dto/LogoutResponse.java
@@ -1,0 +1,45 @@
+package com.study.moya.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class LogoutResponse {
+    private final String status;      // success 또는 error
+    private final String message;     // 응답 메시지
+    private final LocalDateTime timestamp;  // 응답 시간
+    private final String detail;      // 추가적인 상세 정보 (선택적)
+
+    // 성공 응답을 만드는 정적 팩토리 메서드
+    public static LogoutResponse success(String message) {
+        return LogoutResponse.builder()
+                .status("success")
+                .message(message)
+                .timestamp(LocalDateTime.now())
+                .build();
+    }
+
+    // 에러 응답을 만드는 정적 팩토리 메서드
+    public static LogoutResponse error(String message, String detail) {
+        return LogoutResponse.builder()
+                .status("error")
+                .message(message)
+                .detail(detail)
+                .timestamp(LocalDateTime.now())
+                .build();
+    }
+
+    @Override
+    public String toString() {
+        return "LogoutResponse{" +
+                "status='" + status + '\'' +
+                ", message='" + message + '\'' +
+                ", timestamp=" + timestamp +
+                ", detail='" + detail + '\'' +
+                '}';
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/global/config/security/SecurityConfig.java
+++ b/back/moya/src/main/java/com/study/moya/global/config/security/SecurityConfig.java
@@ -57,6 +57,7 @@ public class SecurityConfig {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .formLogin(AbstractHttpConfigurer::disable) // 폼 로그인 비활성화
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authz -> authz
@@ -70,20 +71,7 @@ public class SecurityConfig {
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
-                .formLogin(form -> form
-                        .loginPage("/api/auth/login")
-                        .loginProcessingUrl("/api/auth/login")
-                        .successHandler((request, response, authentication) -> {
-                            response.setContentType("application/json");
-                            response.setCharacterEncoding("UTF-8");
-                            response.getWriter().write("{\"success\": true}");
-                        })
-                        .failureHandler((request, response, exception) -> {
-                            response.setContentType("application/json");
-                            response.setCharacterEncoding("UTF-8");
-                            response.getWriter()
-                                    .write("{\"success\": false, \"message\": \"" + exception.getMessage() + "\"}");
-                        }))
+
 
                 .oauth2Login(oauth2 ->
                         oauth2.authorizationEndpoint(endpoint ->

--- a/back/moya/src/test/java/com/study/moya/auth/AuthControllerLogoutTest.java
+++ b/back/moya/src/test/java/com/study/moya/auth/AuthControllerLogoutTest.java
@@ -1,26 +1,13 @@
 package com.study.moya.auth;
 
 
-import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
-import static org.hibernate.validator.internal.util.Contracts.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.study.moya.auth.dto.LoginRequest;
-import com.study.moya.auth.jwt.JwtTokenProvider.TokenInfo;
+import com.study.moya.Oauth.exception.InvalidTokenException;
 import com.study.moya.auth.service.AuthService;
-import com.study.moya.member.repository.MemberRepository;
+import com.study.moya.redis.RedisService;
+import com.study.moya.auth.dto.LogoutRequest;
+import com.study.moya.auth.dto.LogoutResponse;
 import jakarta.servlet.http.Cookie;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -29,10 +16,21 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.mockito.ArgumentMatchers.any;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -45,112 +43,120 @@ public class AuthControllerLogoutTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @Autowired
-    private MemberRepository memberRepository;
-
-    @Autowired
-    private PasswordEncoder passwordEncoder;
-
     @MockBean
     private AuthService authService;
 
-    private static final String TEST_EMAIL = "test@example.com";
-    private static final String TEST_PASSWORD = "Password123!";
+    @MockBean
+    private RedisService redisService;
 
-    @BeforeEach
-    void setUp() {
-        memberRepository.deleteAll();
-    }
+    private static final String TEST_EMAIL = "test@example.com";
+    private static final String TEST_ACCESS_TOKEN = "test-access-token";
 
     @Test
-    @DisplayName("로그아웃 성공 테스트")
+    @DisplayName("정상적인 로그아웃 테스트")
     void logout_Success() throws Exception {
         // Given
-        // 먼저 로그인을 수행하여 쿠키 설정
-        TokenInfo tokenInfo = new TokenInfo("test-access-token", "test-refresh-token");
-        when(authService.authenticateUser(any(LoginRequest.class))).thenReturn(tokenInfo);
-
-        LoginRequest loginRequest = new LoginRequest(TEST_EMAIL, TEST_PASSWORD);
-
-        // 로그인 수행
-        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(loginRequest)))
-                .andDo(print()) // 로그인 응답 출력
-                .andReturn();
-
-        // 로그인 응답에서 쿠키 확인
-        Cookie[] loginCookies = loginResult.getResponse().getCookies();
-        //log.info("Login response cookies: {}", Arrays.toString(loginCookies));
-
-        // When & Then
-        // 로그아웃 수행 및 검증
-        MvcResult logoutResult = mockMvc.perform(post("/api/auth/logout")
-                        .cookie(loginCookies)) // 로그인에서 받은 쿠키 포함
-                .andDo(print()) // 로그아웃 응답 출력
-                .andExpect(status().isOk())
-                .andExpect(result -> {
-                    Cookie[] cookies = result.getResponse().getCookies();
-                    //log.info("Logout response cookies: {}", Arrays.toString(cookies));
-
-                    // 쿠키가 존재하는지 확인
-                    assertTrue(cookies != null && cookies.length > 0, "응답에 쿠키가 없습니다.");
-
-                    // refresh_token 쿠키를 찾아서 검증
-                    Optional<Cookie> refreshTokenCookie = Arrays.stream(cookies)
-                            .filter(cookie -> "refresh_token".equals(cookie.getName()))
-                            .findFirst();
-
-                    assertTrue(refreshTokenCookie.isPresent(),
-                            "refresh_token 쿠키가 없습니다. 존재하는 쿠키: " +
-                                    Arrays.toString(cookies));
-
-                    assertEquals(0, refreshTokenCookie.get().getMaxAge(),
-                            "쿠키 만료 시간이 0이 아닙니다.");
-                })
-                .andReturn();
-
-        // 추가 로깅
-//        log.info("Login Request: {}", objectMapper.writeValueAsString(loginRequest));
-//        log.info("Login Response Status: {}", loginResult.getResponse().getStatus());
-//        log.info("Logout Response Status: {}", logoutResult.getResponse().getStatus());
-//        log.info("Logout Response Headers: {}", logoutResult.getResponse().getHeaderNames());
-    }
-
-    @Test
-    @DisplayName("로그아웃 요청 시 모든 인증 관련 쿠키가 제거되는지 확인")
-    void logout_RemovesAllAuthCookies() throws Exception {
-        // Given
-        Cookie refreshTokenCookie = new Cookie("refresh_token", "test-refresh-token");
-        refreshTokenCookie.setPath("/");
-        refreshTokenCookie.setHttpOnly(true);
-
-        Cookie jwtCookie = new Cookie("jwt", "test-jwt-token");
-        jwtCookie.setPath("/");
-        jwtCookie.setHttpOnly(true);
+        doNothing().when(authService).logout(any(LogoutRequest.class));
 
         // When & Then
         mockMvc.perform(post("/api/auth/logout")
-                        .cookie(refreshTokenCookie, jwtCookie))
+                        .header("Authorization", "Bearer " + TEST_ACCESS_TOKEN)
+                        .param("email", TEST_EMAIL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("UTF-8"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.message").value("로그아웃되었습니다"))
+                .andExpect(result -> {
+                    MockHttpServletResponse response = result.getResponse();
+                    Cookie[] cookies = response.getCookies();
+                    assertNotNull(cookies);
+                    assertTrue(Arrays.stream(cookies)
+                            .anyMatch(cookie ->
+                                    "refresh_token".equals(cookie.getName()) &&
+                                            cookie.getMaxAge() == 0));
+                });
+    }
+
+    @Test
+    @DisplayName("토큰 없이 로그아웃 시도")
+    void logout_WithoutToken() throws Exception {
+        mockMvc.perform(post("/api/auth/logout")
+                        .param("email", TEST_EMAIL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("UTF-8"))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value("error"))
+                .andExpect(jsonPath("$.message").value("Authorization 헤더가 필요합니다"));
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 토큰으로 로그아웃 시도")
+    void logout_WithInvalidToken() throws Exception {
+        // Given
+        doThrow(new InvalidTokenException("유효하지 않은 Access Token입니다."))
+                .when(authService).logout(any(LogoutRequest.class));
+
+        // When & Then
+        mockMvc.perform(post("/api/auth/logout")
+                        .header("Authorization", "Bearer invalid-token")
+                        .param("email", TEST_EMAIL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("UTF-8"))
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value("error"))
+                .andExpect(jsonPath("$.message").value("인증 오류"));
+    }
+
+    @Test
+    @DisplayName("쿠키 삭제 확인")
+    void logout_CheckCookieDeletion() throws Exception {
+        // Given
+        doNothing().when(authService).logout(any(LogoutRequest.class));
+
+        // When & Then
+        mockMvc.perform(post("/api/auth/logout")
+                        .header("Authorization", "Bearer " + TEST_ACCESS_TOKEN)
+                        .cookie(new Cookie("refresh_token", "test-refresh-token"))
+                        .param("email", TEST_EMAIL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("UTF-8"))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(result -> {
-                    Cookie[] responseCookies = result.getResponse().getCookies();
-                    assertNotNull(responseCookies, "응답 쿠키가 null입니다");
-
-                    List<Cookie> expiredCookies = Arrays.stream(responseCookies)
-                            .filter(cookie -> cookie.getMaxAge() == 0)
-                            .collect(Collectors.toList());
-
-
-
-                            expiredCookies.stream()
-                                    .map(Cookie::getName)
-                                    .collect(Collectors.joining(", "));
-
-                    assertTrue(expiredCookies.stream()
-                                    .anyMatch(cookie -> "refresh_token".equals(cookie.getName())),
-                            "refresh_token 쿠키가 만료되지 않았습니다");
+                    Cookie[] cookies = result.getResponse().getCookies();
+                    assertNotNull(cookies, "쿠키가 null입니다");
+                    Optional<Cookie> refreshTokenCookie = Arrays.stream(cookies)
+                            .filter(cookie -> "refresh_token".equals(cookie.getName()))
+                            .findFirst();
+                    assertTrue(refreshTokenCookie.isPresent(), "refresh_token 쿠키가 없습니다");
+                    assertEquals(0, refreshTokenCookie.get().getMaxAge(), "쿠키가 즉시 만료되지 않았습니다");
                 });
+    }
+
+    @Test
+    @DisplayName("Redis에서 토큰 삭제 확인")
+    void logout_CheckRedisTokenDeletion() throws Exception {
+        // Given
+        String email = TEST_EMAIL;
+        String accessToken = TEST_ACCESS_TOKEN;
+
+        // RedisService의 동작 모킹
+        when(redisService.getAccessToken(email)).thenReturn(accessToken);
+
+        // When & Then
+        mockMvc.perform(post("/api/auth/logout")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("email", email)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("success"));
+
+        // 메서드 호출 검증
+        verify(authService, times(1)).logout(any(LogoutRequest.class));
     }
 }


### PR DESCRIPTION
# OAuth 로그아웃 기능 구현
## 🔍 PR 개요
OAuth 로그인 사용자의 안전한 로그아웃을 위한 기능을 구현했습니다. Redis를 활용한 토큰 관리와 보안 처리를 포함합니다.

## 📝 변경사항
### 로그아웃 API 엔드포인트 구현
- `/api/auth/logout` POST 엔드포인트 추가
- Authorization 헤더를 통한 토큰 검증 로직 구현
- 응답 형식 표준화 (LogoutResponse DTO)

### Redis 토큰 관리 기능 구현
- Redis 토큰 삭제 메서드 추가
- 토큰 검증 로직 구현
- Redis 서비스 예외 처리 강화

### 보안 기능 강화
- SecurityContext 클리어 로직 추가
- HttpOnly 쿠키 처리 구현
- 토큰 유효성 검증 로직 추가

## 🔗 관련 이슈
-Close #52 로그아웃 기능 설정

## ✅ 체크리스트
### 로컬 테스트
- [x] 정상 로그아웃 테스트 완료
- [x] 토큰 누락 시나리오 테스트 완료
- [x] 유효하지 않은 토큰 테스트 완료
- [x] Redis 연동 테스트 완료

### JPA 성능 최적화
- [ ] 엔티티에 적절한 인덱스 추가
  - 이 PR에서는 해당 없음
- [ ] N+1 문제 해결
  - Redis 사용으로 해당 없음

### 캐시 정책
- [x] 캐시 적용 필요성 검토
  - 로그아웃은 일회성 작업으로 캐시 불필요
  - Redis는 토큰 저장소로만 사용

### DB 스키마 변경
- [ ] 테이블 생성/수정
  - Redis 키-값 구조만 사용하여 스키마 변경 없음

### API 문서화
- [x] Controller에 @Tag 추가
  - `@Tag(name = "Auth", description = "인증 관련 API")`
- [x] API 설명 추가
  - Swagger 문서화 완료

## 🚨 주의사항
### 1. 설정 관련
- Redis 연결 설정 필요
- Security 설정에서 로그아웃 엔드포인트 권한 설정 필요

### 2. 운영 관련
- Redis 장애 시 토큰 관리에 영향
- 대량의 동시 로그아웃 요청 시 Redis 부하 고려

### 3. 에러 처리
- InvalidTokenException: 유효하지 않은 토큰
- MissingRequestHeaderException: 헤더 누락
- Redis 관련 예외는 RuntimeException으로 래핑

### 4. 확장 가이드
- LogoutResponse DTO 확장 시 builder 패턴 활용
- 새로운 예외 추가 시 GlobalExceptionHandler에 처리 로직 추가
- 토큰 검증 로직 확장 시 AuthService에 메서드 추가