### PR TITLE
KAN-121--RoadMap_Entity

### DIFF
--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/config/OpenAIConfig.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/config/OpenAIConfig.java
@@ -1,0 +1,23 @@
+package com.study.moya.ai_roadmap.config;
+
+
+import com.theokanning.openai.service.OpenAiService;
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenAIConfig {
+
+    @Value("${openai.api.models.roadmap_generation.model}")
+    private String roadmapModel;
+
+    @Value("${openai.api.models.category_classification.model}")
+    private String searchModel;
+
+    @Bean
+    public OpenAiService openAiService(@Value("${openai.api.key}") String apiKey) {
+        return new OpenAiService(apiKey, Duration.ofSeconds(300));
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/controller/CategoryController.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/controller/CategoryController.java
@@ -1,0 +1,77 @@
+package com.study.moya.ai_roadmap.controller;
+
+
+import com.study.moya.ai_roadmap.dto.request.BulkCategoryRequest;
+import com.study.moya.ai_roadmap.dto.request.CreateCategoryRequest;
+import com.study.moya.ai_roadmap.dto.request.UpdateCategoryRequest;
+import com.study.moya.ai_roadmap.dto.response.CategoryHierarchyResponse;
+import com.study.moya.ai_roadmap.dto.response.CategoryResponse;
+import com.study.moya.ai_roadmap.service.CategoryService;
+import java.net.URI;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/categories")
+@RequiredArgsConstructor
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @PostMapping
+    public ResponseEntity<Void> createCategory(@RequestBody CreateCategoryRequest request) {
+        Long id = categoryService.createCategory(request);
+        return ResponseEntity.created(URI.create("/api/categories/" + id)).build();
+    }
+
+    @GetMapping("/main")
+    public ResponseEntity<List<CategoryResponse>> getMainCategories() {
+        return ResponseEntity.ok(categoryService.getMainCategories());
+    }
+
+    @GetMapping("/{parentId}/sub")
+    public ResponseEntity<List<CategoryResponse>> getSubCategories(@PathVariable Long parentId) {
+        return ResponseEntity.ok(categoryService.getSubCategories(parentId));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> updateCategory(
+            @PathVariable Long id,
+            @RequestBody UpdateCategoryRequest request
+    ) {
+        categoryService.updateCategory(id, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteCategory(@PathVariable Long id) {
+        categoryService.deleteCategory(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/bulk")
+    public ResponseEntity<Void> processBulkOperations(@RequestBody BulkCategoryRequest request) {
+        categoryService.processBulkOperations(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/hierarchy")
+    public ResponseEntity<List<CategoryHierarchyResponse>> getCategoryHierarchy() {
+        return ResponseEntity.ok(categoryService.getCategoryHierarchy());
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException e) {
+        return ResponseEntity.badRequest().body(e.getMessage());
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/controller/RoadmapController.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/controller/RoadmapController.java
@@ -1,0 +1,53 @@
+package com.study.moya.ai_roadmap.controller;
+
+import com.study.moya.ai_roadmap.dto.request.RoadmapRequest;
+import com.study.moya.ai_roadmap.dto.response.WeeklyRoadmapResponse;
+import com.study.moya.ai_roadmap.service.RoadmapService;
+import com.study.moya.ai_roadmap.service.WorksheetService;
+import jakarta.validation.Valid;
+import java.util.concurrent.CompletableFuture;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Slf4j
+@RequestMapping("/api/roadmap")
+@RequiredArgsConstructor
+public class RoadmapController {
+
+    private final RoadmapService roadmapService;
+    private final WorksheetService worksheetService;
+
+    @PostMapping("/generate")
+    public CompletableFuture<ResponseEntity<WeeklyRoadmapResponse>> generateWeeklyRoadmap(
+            @Valid @RequestBody RoadmapRequest request
+    ) {
+        log.info("작동해버리기~============================");
+        return roadmapService.generateWeeklyRoadmapAsync(request)
+                .thenApply(response -> ResponseEntity.ok(response))
+                .exceptionally(ex -> {
+                    // 예외 발생 시 처리
+                    return ResponseEntity.status(500).body(null);
+                });
+    }
+
+    @PostMapping("/{roadmapId}/worksheets")
+    public ResponseEntity<Void> generateWorksheets(@PathVariable Long roadmapId) {
+        log.info("로드맵 ID: {}의 학습지 생성 시작", roadmapId);
+        worksheetService.generateAllWorksheets(roadmapId)
+                .thenRun(() -> {
+                    log.info("로드맵 ID: {}의 학습지 생성 완료", roadmapId);
+                })
+                .exceptionally(ex -> {
+                    log.error("학습지 생성 중 오류 발생: {}", ex.getMessage());
+                    return null;
+                });
+        return ResponseEntity.accepted().build();
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/domain/Category.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/domain/Category.java
@@ -1,0 +1,45 @@
+package com.study.moya.ai_roadmap.domain;
+
+import com.study.moya.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "categories")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Category extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Category parent;
+
+    private int depth;
+
+    @Builder
+    private Category(String name, Category parent) {
+        this.name = name;
+        this.parent = parent;
+        this.depth = (parent != null) ? parent.getDepth() + 1 : 0;
+    }
+
+    public void updateName(String name) {
+        this.name = name;
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/domain/DailyPlan.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/domain/DailyPlan.java
@@ -1,0 +1,59 @@
+package com.study.moya.ai_roadmap.domain;
+
+import com.study.moya.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "daily_plans")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class DailyPlan extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Integer dayNumber;
+
+    @Column(nullable = false)
+    private String keyword;
+
+    @Column(columnDefinition = "TEXT")
+    private String workSheet;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "weekly_plan_id")
+    private WeeklyPlan weeklyPlan;
+
+    @Builder
+    private DailyPlan(Integer dayNumber, String keyword, String workSheet, WeeklyPlan weeklyPlan) {
+        validateDayNumber(dayNumber);
+        this.dayNumber = dayNumber;
+        this.keyword = keyword;
+        this.workSheet = workSheet;
+        this.weeklyPlan = weeklyPlan;
+    }
+
+    public void updateWorkSheet(String workSheet) {
+        this.workSheet = workSheet;
+    }
+
+    private void validateDayNumber(Integer dayNumber) {
+        if (dayNumber == null || dayNumber < 1 || dayNumber > 7) {
+            throw new IllegalArgumentException("일자는 1-7 사이여야 합니다.");
+        }
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/domain/Quiz.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/domain/Quiz.java
@@ -1,0 +1,54 @@
+package com.study.moya.ai_roadmap.domain;
+
+import com.study.moya.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "quizzes")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Quiz extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 500)
+    private String question;
+
+    @Column(nullable = false, length = 500)
+    private String answer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "daily_plan_id")
+    private DailyPlan dailyPlan;
+
+    @Builder
+    public Quiz(String question, String answer, DailyPlan dailyPlan) {
+        validateQuiz(question, answer);
+        this.question = question;
+        this.answer = answer;
+        this.dailyPlan = dailyPlan;
+    }
+
+    private void validateQuiz(String question, String answer) {
+        if (question == null || question.isBlank()) {
+            throw new IllegalArgumentException("문제는 필수입니다.");
+        }
+        if (answer == null || answer.isBlank()) {
+            throw new IllegalArgumentException("답변은 필수입니다.");
+        }
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/domain/RoadMap.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/domain/RoadMap.java
@@ -1,0 +1,67 @@
+package com.study.moya.ai_roadmap.domain;
+
+import com.study.moya.BaseEntity;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "roadmaps")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class RoadMap extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String topic;
+
+    @Column(columnDefinition = "TEXT")
+    private String evaluation;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    @ElementCollection
+    @CollectionTable(name = "roadmap_tips", joinColumns = @JoinColumn(name = "roadmap_id"))
+    @Column(name = "tip", columnDefinition = "TEXT")
+    private List<String> overallTips = new ArrayList<>();
+
+    @Builder
+    private RoadMap(String topic, String evaluation, List<String> overallTips, Category category) {
+        this.topic = topic;
+        this.evaluation = evaluation;
+        this.category = category;
+        if (overallTips != null) {
+            this.overallTips = overallTips;
+        }
+    }
+
+    public void updateTopic(String topic) {
+        this.topic = topic;
+    }
+
+    public void updateEvaluation(String evaluation) {
+        this.evaluation = evaluation;
+    }
+
+    public void updateCategory(Category category) {
+        this.category = category;
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/domain/WeeklyPlan.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/domain/WeeklyPlan.java
@@ -1,0 +1,51 @@
+package com.study.moya.ai_roadmap.domain;
+
+import com.study.moya.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "weekly_plans")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class WeeklyPlan extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Integer weekNumber;
+
+    @Column(nullable = false)
+    private String keyword;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "roadmap_id")
+    private RoadMap roadMap;
+
+    @Builder
+    private WeeklyPlan(Integer weekNumber, String keyword, RoadMap roadMap) {
+        validateWeekNumber(weekNumber);
+        this.weekNumber = weekNumber;
+        this.keyword = keyword;
+        this.roadMap = roadMap;
+    }
+
+    private void validateWeekNumber(Integer weekNumber) {
+        if (weekNumber == null || weekNumber < 1) {
+            throw new IllegalArgumentException("주차는 1 이상이어야 합니다.");
+        }
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/dto/request/BulkCategoryRequest.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/dto/request/BulkCategoryRequest.java
@@ -1,0 +1,30 @@
+package com.study.moya.ai_roadmap.dto.request;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BulkCategoryRequest {
+    private List<CategoryOperation> operations;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CategoryOperation {
+        private OperationType operation;
+        private Long id;  // UPDATE, DELETE 시 사용
+        private String name;  // CREATE, UPDATE 시 사용
+        private Long parentId;  // CREATE 시 사용
+    }
+
+    public enum OperationType {
+        CREATE, UPDATE, DELETE
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/dto/request/CreateCategoryRequest.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/dto/request/CreateCategoryRequest.java
@@ -1,0 +1,15 @@
+package com.study.moya.ai_roadmap.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateCategoryRequest {
+    private String name;
+    private Long parentId;
+}

--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/dto/request/RoadmapRequest.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/dto/request/RoadmapRequest.java
@@ -1,0 +1,41 @@
+package com.study.moya.ai_roadmap.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class RoadmapRequest {
+
+    @NotBlank(message = "Main category is required")
+    private String mainCategory; // 대분류
+
+    @NotBlank(message = "Subcategory is required")
+    private String subCategory; // 중분류
+
+    private String currentLevel;
+
+    @NotNull(message = "Duration is required")
+    @Min(value = 1, message = "Duration must be at least 1 week")
+    private Integer duration; // 주 단위
+
+    // 기본 생성자
+    public RoadmapRequest() {
+    }
+
+    // toString 메소드 오버라이드
+    @Override
+    public String toString() {
+        return "RoadmapRequest{" +
+                ", currentLevel='" + currentLevel + '\'' +
+                ", mainCategory='" + mainCategory + '\'' +
+                ", subCategory='" + subCategory + '\'' +
+                ", duration=" + duration +
+                '}';
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/dto/request/UpdateCategoryRequest.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/dto/request/UpdateCategoryRequest.java
@@ -1,0 +1,14 @@
+package com.study.moya.ai_roadmap.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateCategoryRequest {
+    private String name;
+}

--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/dto/response/CategoryHierarchyResponse.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/dto/response/CategoryHierarchyResponse.java
@@ -1,0 +1,22 @@
+package com.study.moya.ai_roadmap.dto.response;
+
+import com.study.moya.ai_roadmap.domain.Category;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CategoryHierarchyResponse {
+    private Long id;
+    private String name;
+    private List<CategoryHierarchyResponse> subCategories;
+
+    public static CategoryHierarchyResponse from(Category category, List<CategoryHierarchyResponse> subCategories) {
+        return CategoryHierarchyResponse.builder()
+                .id(category.getId())
+                .name(category.getName())
+                .subCategories(subCategories)
+                .build();
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/dto/response/CategoryResponse.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/dto/response/CategoryResponse.java
@@ -1,0 +1,23 @@
+package com.study.moya.ai_roadmap.dto.response;
+
+import com.study.moya.ai_roadmap.domain.Category;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CategoryResponse {
+    private Long id;
+    private String name;
+    private int depth;
+    private Long parentId;
+
+    public static CategoryResponse from(Category category) {
+        return CategoryResponse.builder()
+                .id(category.getId())
+                .name(category.getName())
+                .depth(category.getDepth())
+                .parentId(category.getParent() != null ? category.getParent().getId() : null)
+                .build();
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/dto/response/WeeklyRoadmapResponse.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/dto/response/WeeklyRoadmapResponse.java
@@ -1,0 +1,34 @@
+package com.study.moya.ai_roadmap.dto.response;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class WeeklyRoadmapResponse {
+
+    private List<WeeklyPlan> weeklyPlans; // 주차별 계획
+    private List<String> overallTips; // 전체 팁
+    private String curriculumEvaluation; // 커리큘럼 평가
+    private String hasRestrictedTopics; // 금지된 주제 여부
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    public static class WeeklyPlan {
+        private int week; // 주차
+        private String weeklyKeyword; // 주차별 키워드
+        private List<DailyPlan> dailyPlans; // 일별 계획
+    }
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    public static class DailyPlan {
+        private int day; // 날짜
+        private String dailyKeyword; // 일별 키워드
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/repository/CategoryRepository.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/repository/CategoryRepository.java
@@ -1,0 +1,21 @@
+package com.study.moya.ai_roadmap.repository;
+
+import com.study.moya.ai_roadmap.domain.Category;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    @Query("SELECT c FROM Category c WHERE c.parent IS NULL")
+    List<Category> findAllMainCategories();
+
+    @Query("SELECT c FROM Category c WHERE c.parent.id = :parentId")
+    List<Category> findSubCategories(@Param("parentId") Long parentId);
+
+    boolean existsByNameAndParentId(String name, Long parentId);
+
+    @Query("SELECT CASE WHEN COUNT(c) > 0 THEN true ELSE false END FROM Category c WHERE c.parent.id = :categoryId")
+    boolean hasSubCategories(@Param("categoryId") Long categoryId);
+}

--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/repository/DailyPlanRepository.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/repository/DailyPlanRepository.java
@@ -1,0 +1,56 @@
+package com.study.moya.ai_roadmap.repository;
+
+import com.study.moya.ai_roadmap.domain.DailyPlan;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DailyPlanRepository extends JpaRepository<DailyPlan, Long> {
+
+    // 로드맵 ID로 모든 DailyPlan을 일자 순으로 조회
+    @Query("SELECT d FROM DailyPlan d " +
+            "JOIN FETCH d.weeklyPlan w " +
+            "WHERE w.roadMap.id = :roadmapId " +
+            "ORDER BY w.weekNumber, d.dayNumber")
+    List<DailyPlan> findAllByWeeklyPlan_RoadMap_IdOrderByDayNumber(@Param("roadmapId") Long roadmapId);
+
+    // 특정 주차의 모든 DailyPlan 조회
+    @Query("SELECT d FROM DailyPlan d " +
+            "WHERE d.weeklyPlan.id = :weeklyPlanId " +
+            "ORDER BY d.dayNumber")
+    List<DailyPlan> findAllByWeeklyPlanIdOrderByDayNumber(@Param("weeklyPlanId") Long weeklyPlanId);
+
+    // 워크시트가 아직 생성되지 않은 DailyPlan 조회
+    @Query("SELECT d FROM DailyPlan d " +
+            "WHERE d.weeklyPlan.roadMap.id = :roadmapId " +
+            "AND (d.workSheet IS NULL OR d.workSheet = '') " +
+            "ORDER BY d.weeklyPlan.weekNumber, d.dayNumber")
+    List<DailyPlan> findAllWithoutWorksheetByRoadmapId(@Param("roadmapId") Long roadmapId);
+
+    // 특정 기간의 DailyPlan 조회
+    @Query("SELECT d FROM DailyPlan d " +
+            "WHERE d.weeklyPlan.roadMap.id = :roadmapId " +
+            "AND d.weeklyPlan.weekNumber = :weekNumber " +
+            "AND d.dayNumber BETWEEN :startDay AND :endDay " +
+            "ORDER BY d.dayNumber")
+    List<DailyPlan> findByRoadmapIdAndWeekNumberAndDayNumberBetween(
+            @Param("roadmapId") Long roadmapId,
+            @Param("weekNumber") Integer weekNumber,
+            @Param("startDay") Integer startDay,
+            @Param("endDay") Integer endDay
+    );
+
+    // 워크시트 업데이트가 필요한 DailyPlan 수 조회
+    @Query("SELECT COUNT(d) FROM DailyPlan d " +
+            "WHERE d.weeklyPlan.roadMap.id = :roadmapId " +
+            "AND (d.workSheet IS NULL OR d.workSheet = '')")
+    long countPendingWorksheets(@Param("roadmapId") Long roadmapId);
+
+    // 특정 로드맵의 총 DailyPlan 수 조회
+    @Query("SELECT COUNT(d) FROM DailyPlan d " +
+            "WHERE d.weeklyPlan.roadMap.id = :roadmapId")
+    long countTotalDailyPlans(@Param("roadmapId") Long roadmapId);
+}

--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/repository/RoadMapRepository.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/repository/RoadMapRepository.java
@@ -1,0 +1,9 @@
+package com.study.moya.ai_roadmap.repository;
+
+import com.study.moya.ai_roadmap.domain.RoadMap;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoadMapRepository extends JpaRepository<RoadMap, Long> {
+}

--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/repository/WeeklyPlanRepository.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/repository/WeeklyPlanRepository.java
@@ -1,0 +1,9 @@
+package com.study.moya.ai_roadmap.repository;
+
+import com.study.moya.ai_roadmap.domain.WeeklyPlan;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface WeeklyPlanRepository extends JpaRepository<WeeklyPlan, Long> {
+}

--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/service/CategoryService.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/service/CategoryService.java
@@ -1,0 +1,176 @@
+package com.study.moya.ai_roadmap.service;
+
+import com.study.moya.ai_roadmap.domain.Category;
+import com.study.moya.ai_roadmap.dto.request.BulkCategoryRequest;
+import com.study.moya.ai_roadmap.dto.request.BulkCategoryRequest.CategoryOperation;
+import com.study.moya.ai_roadmap.dto.request.CreateCategoryRequest;
+import com.study.moya.ai_roadmap.dto.request.UpdateCategoryRequest;
+import com.study.moya.ai_roadmap.dto.response.CategoryHierarchyResponse;
+import com.study.moya.ai_roadmap.dto.response.CategoryResponse;
+import com.study.moya.ai_roadmap.repository.CategoryRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    @Transactional
+    public Long createCategory(CreateCategoryRequest request) {
+        Category parent = null;
+        if (request.getParentId() != null) {
+            parent = categoryRepository.findById(request.getParentId())
+                    .orElseThrow(() -> new IllegalArgumentException("Parent category not found"));
+
+            if (parent.getDepth() > 0) {
+                throw new IllegalArgumentException("Cannot create category under sub-category");
+            }
+        }
+
+        if (categoryRepository.existsByNameAndParentId(request.getName(), request.getParentId())) {
+            throw new IllegalArgumentException("Category with this name already exists in this level");
+        }
+
+        Category category = Category.builder()
+                .name(request.getName())
+                .parent(parent)
+                .build();
+
+        return categoryRepository.save(category).getId();
+    }
+
+    public List<CategoryResponse> getMainCategories() {
+        return categoryRepository.findAllMainCategories().stream()
+                .map(CategoryResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    public List<CategoryResponse> getSubCategories(Long parentId) {
+        return categoryRepository.findSubCategories(parentId).stream()
+                .map(CategoryResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void updateCategory(Long id, UpdateCategoryRequest request) {
+        Category category = categoryRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Category not found"));
+        category.updateName(request.getName());
+    }
+
+    @Transactional
+    public void deleteCategory(Long id) {
+        Category category = categoryRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Category not found"));
+
+        if (categoryRepository.hasSubCategories(id)) {
+            throw new IllegalArgumentException("Cannot delete category with sub-categories");
+        }
+
+        categoryRepository.delete(category);
+    }
+
+    @Transactional
+    public void processBulkOperations(BulkCategoryRequest request) {
+        List<String> errors = new ArrayList<>();
+
+        // 모든 ID를 한 번에 조회하여 캐싱
+        List<Long> ids = request.getOperations().stream()
+                .map(CategoryOperation::getId)
+                .filter(id -> id != null)
+                .collect(Collectors.toList());
+
+        Map<Long, Category> categoryMap = categoryRepository.findAllById(ids).stream()
+                .collect(Collectors.toMap(Category::getId, category -> category));
+
+        for (int i = 0; i < request.getOperations().size(); i++) {
+            CategoryOperation operation = request.getOperations().get(i);
+            try {
+                processOperation(operation, categoryMap);
+            } catch (Exception e) {
+                errors.add(String.format("Operation %d failed: %s", i, e.getMessage()));
+            }
+        }
+
+        if (!errors.isEmpty()) {
+            throw new IllegalArgumentException("Some operations failed: " + String.join(", ", errors));
+        }
+    }
+
+    private void processOperation(CategoryOperation operation, Map<Long, Category> categoryMap) {
+        switch (operation.getOperation()) {
+            case CREATE -> createCategoryFromOperation(operation);
+            case UPDATE -> updateCategoryFromOperation(operation, categoryMap);
+            case DELETE -> deleteCategoryFromOperation(operation, categoryMap);
+        }
+    }
+
+    private void createCategoryFromOperation(CategoryOperation operation) {
+        Category parent = null;
+        if (operation.getParentId() != null) {
+            parent = categoryRepository.findById(operation.getParentId())
+                    .orElseThrow(() -> new IllegalArgumentException("Parent category not found"));
+
+            if (parent.getDepth() > 0) {
+                throw new IllegalArgumentException("Cannot create category under sub-category");
+            }
+        }
+
+        if (categoryRepository.existsByNameAndParentId(operation.getName(), operation.getParentId())) {
+            throw new IllegalArgumentException("Category with this name already exists in this level");
+        }
+
+        Category category = Category.builder()
+                .name(operation.getName())
+                .parent(parent)
+                .build();
+
+        categoryRepository.save(category);
+    }
+
+    private void updateCategoryFromOperation(CategoryOperation operation, Map<Long, Category> categoryMap) {
+        Category category = categoryMap.get(operation.getId());
+        if (category == null) {
+            throw new IllegalArgumentException("Category not found");
+        }
+        category.updateName(operation.getName());
+    }
+
+    private void deleteCategoryFromOperation(CategoryOperation operation, Map<Long, Category> categoryMap) {
+        Category category = categoryMap.get(operation.getId());
+        if (category == null) {
+            throw new IllegalArgumentException("Category not found");
+        }
+
+        if (categoryRepository.hasSubCategories(category.getId())) {
+            throw new IllegalArgumentException("Cannot delete category with sub-categories");
+        }
+
+        categoryRepository.delete(category);
+    }
+
+    @Transactional(readOnly = true)
+    public List<CategoryHierarchyResponse> getCategoryHierarchy() {
+        List<Category> mainCategories = categoryRepository.findAllMainCategories();
+        return mainCategories.stream()
+                .map(category -> buildCategoryHierarchy(category))
+                .collect(Collectors.toList());
+    }
+
+    private CategoryHierarchyResponse buildCategoryHierarchy(Category category) {
+        List<Category> subCategories = categoryRepository.findSubCategories(category.getId());
+        List<CategoryHierarchyResponse> subCategoryResponses = subCategories.stream()
+                .map(subCategory -> CategoryHierarchyResponse.from(subCategory, List.of()))
+                .collect(Collectors.toList());
+
+        return CategoryHierarchyResponse.from(category, subCategoryResponses);
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/service/RoadmapPromptService.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/service/RoadmapPromptService.java
@@ -1,0 +1,35 @@
+package com.study.moya.ai_roadmap.service;
+
+import com.study.moya.ai_roadmap.dto.request.RoadmapRequest;
+import com.theokanning.openai.completion.chat.ChatMessage;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RoadmapPromptService {
+
+    @Value("${chatgpt.system-prompt}")
+    private String systemPrompt;
+
+    public String createPrompt(RoadmapRequest request) {
+        return String.format(
+                "대분류: %s\n" +
+                        "중분류: %s\n" +
+                        "현재 수준: %s\n" +
+                        "기간: %s주\n\n" +
+                        "위의 정보를 기반으로 주차별 키워드와 일별 키워드를 포함한 로드맵을 작성해주세요.",
+                request.getMainCategory(),
+                request.getSubCategory(),
+                request.getCurrentLevel(),
+                request.getDuration()
+        );
+    }
+
+    public List<ChatMessage> buildMessages(String userPrompt) {
+        return List.of(
+                new ChatMessage("system", systemPrompt),
+                new ChatMessage("user", userPrompt)
+        );
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/service/RoadmapService.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/service/RoadmapService.java
@@ -1,0 +1,132 @@
+package com.study.moya.ai_roadmap.service;
+
+import com.study.moya.ai_roadmap.domain.DailyPlan;
+import com.study.moya.ai_roadmap.domain.RoadMap;
+import com.study.moya.ai_roadmap.domain.WeeklyPlan;
+import com.study.moya.ai_roadmap.dto.request.RoadmapRequest;
+import com.study.moya.ai_roadmap.dto.response.WeeklyRoadmapResponse;
+import com.study.moya.ai_roadmap.repository.DailyPlanRepository;
+import com.study.moya.ai_roadmap.repository.RoadMapRepository;
+import com.study.moya.ai_roadmap.repository.WeeklyPlanRepository;
+import com.study.moya.ai_roadmap.util.RoadmapResponseParser;
+import com.theokanning.openai.Usage;
+import com.theokanning.openai.completion.chat.ChatCompletionRequest;
+import com.theokanning.openai.completion.chat.ChatCompletionResult;
+import com.theokanning.openai.service.OpenAiService;
+import java.util.concurrent.CompletableFuture;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RoadmapService {
+
+    @Value("${openai.api.models.roadmap_generation.model}")
+    private String roadmapModel;
+
+    private final OpenAiService openAiService;
+    private final RoadmapPromptService promptService;
+    private final RoadmapResponseParser responseParser;
+
+    private final RoadMapRepository roadMapRepository;
+    private final WeeklyPlanRepository weeklyPlanRepository;
+    private final DailyPlanRepository dailyPlanRepository;
+
+    @Async
+    public CompletableFuture<WeeklyRoadmapResponse> generateWeeklyRoadmapAsync(RoadmapRequest request) {
+        return CompletableFuture.supplyAsync(() -> {
+            log.info("로드맵 생성 시작");
+
+            String prompt = promptService.createPrompt(request);
+            log.info("생성된 Prompt:\n{}", prompt);
+
+            ChatCompletionRequest completionRequest = ChatCompletionRequest.builder()
+                    .model(roadmapModel)
+                    .messages(promptService.buildMessages(prompt))
+                    .temperature(0.8)
+                    .maxTokens(2000)
+                    .build();
+
+            log.info("OpenAI API 요청 준비 완료: {}", completionRequest);
+
+            try {
+                log.info("OpenAI API 호출 시작...");
+                ChatCompletionResult chatCompletion = openAiService.createChatCompletion(completionRequest);
+
+                String apiResponse = chatCompletion.getChoices().get(0).getMessage().getContent();
+                log.info("OpenAI API 응답 수신 완료:\n{}", apiResponse);
+
+                logTokenUsage(chatCompletion.getUsage());
+
+                // 응답 파싱
+                WeeklyRoadmapResponse response = responseParser.parseResponse(apiResponse);
+
+                // 파싱된 응답을 엔티티로 저장
+                saveCurriculum(request.getSubCategory(), response);
+
+                return response;
+            } catch (Exception e) {
+                log.error("OpenAI API 호출 중 예외 발생:", e);
+                throw new RuntimeException("OpenAI API 호출 실패", e);
+            }
+        });
+    }
+
+    @Transactional
+    public Long saveCurriculum(String topic, WeeklyRoadmapResponse response) {
+        log.info("커리큘럼 저장 시작");
+
+        // RoadMap 생성
+        RoadMap roadMap = RoadMap.builder()
+                .topic(topic)
+                .evaluation(response.getCurriculumEvaluation())
+                .overallTips(response.getOverallTips())
+                .build();
+
+        // 먼저 RoadMap을 저장하여 ID를 확보
+        RoadMap savedRoadMap = roadMapRepository.save(roadMap);
+
+        // WeeklyPlan 생성 및 저장
+        for (WeeklyRoadmapResponse.WeeklyPlan weeklyPlanDto : response.getWeeklyPlans()) {
+            WeeklyPlan weeklyPlan = WeeklyPlan.builder()
+                    .weekNumber(weeklyPlanDto.getWeek())
+                    .keyword(weeklyPlanDto.getWeeklyKeyword())
+                    .roadMap(savedRoadMap)  // 저장된 RoadMap 참조
+                    .build();
+
+            // WeeklyPlan 저장
+            WeeklyPlan savedWeeklyPlan = weeklyPlanRepository.save(weeklyPlan);
+
+            // DailyPlan 생성 및 저장
+            for (WeeklyRoadmapResponse.DailyPlan dailyPlanDto : weeklyPlanDto.getDailyPlans()) {
+                DailyPlan dailyPlan = DailyPlan.builder()
+                        .dayNumber(dailyPlanDto.getDay())
+                        .keyword(dailyPlanDto.getDailyKeyword())
+                        .weeklyPlan(savedWeeklyPlan)  // 저장된 WeeklyPlan 참조
+                        .build();
+
+                dailyPlanRepository.save(dailyPlan);
+            }
+        }
+
+        log.info("커리큘럼 저장 완료. ID: {}", savedRoadMap.getId());
+
+        return savedRoadMap.getId();
+    }
+
+    private void logTokenUsage(Usage usage) {
+        if (usage != null) {
+            log.info("OpenAI 토큰 사용량 - Prompt Tokens: {}, Completion Tokens: {}, Total Tokens: {}",
+                    usage.getPromptTokens(),
+                    usage.getCompletionTokens(),
+                    usage.getTotalTokens());
+        } else {
+            log.warn("OpenAI 토큰 사용량 정보를 가져올 수 없습니다.");
+        }
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/service/WorksheetPromptService.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/service/WorksheetPromptService.java
@@ -1,0 +1,54 @@
+package com.study.moya.ai_roadmap.service;
+
+import com.study.moya.ai_roadmap.domain.DailyPlan;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WorksheetPromptService {
+
+    private static final String SYSTEM_PROMPT = """
+        당신은 프로그래밍 교육 전문가입니다. 주어진 3일간의 학습 키워드에 대해 상세한 학습 가이드를 작성해주세요.
+        
+        응답은 반드시 아래 형식을 따라주세요. 절대로 마크다운이나 특수문자, 번호 매기기를 사용하지 마세요.
+        
+        === DAY {일차} ===
+        [여기에 학습 가이드 내용을 자연스러운 문장으로 작성]
+        
+        === DAY {일차} ===
+        [여기에 학습 가이드 내용을 자연스러운 문장으로 작성]
+        
+        === DAY {일차} ===
+        [여기에 학습 가이드 내용을 자연스러운 문장으로 작성]
+        
+        각 일자별 학습 가이드는 다음 내용을 자연스러운 문장으로 포함해야 합니다:
+        - 해당 주제의 중요성
+        - 핵심 학습 내용
+        - 실제 활용 방법
+        - 실습 예제나 실무 활용 사례
+        - 학습 시 주의사항
+        
+        특별 지시사항:
+        - 번호나 불릿 포인트(-, * 등)를 사용하지 마세요
+        - 마크다운 형식(#, ``` 등)을 사용하지 마세요
+        - JSON 형식을 사용하지 마세요
+        - 각 일자는 반드시 === DAY {일차} === 형식으로 구분해주세요
+        """;
+
+    public String createPrompt(List<DailyPlan> dailyPlans) {
+        StringBuilder promptBuilder = new StringBuilder();
+        promptBuilder.append(SYSTEM_PROMPT).append("\n\n");
+        promptBuilder.append("다음 키워드들에 대한 학습 가이드를 작성해주세요:\n");
+
+        for (DailyPlan plan : dailyPlans) {
+            promptBuilder.append(String.format("Day %d: %s\n",
+                    plan.getDayNumber(), plan.getKeyword()));
+        }
+
+        return promptBuilder.toString();
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/service/WorksheetService.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/service/WorksheetService.java
@@ -1,0 +1,134 @@
+package com.study.moya.ai_roadmap.service;
+
+import com.study.moya.ai_roadmap.domain.DailyPlan;
+import com.study.moya.ai_roadmap.repository.DailyPlanRepository;
+import com.study.moya.ai_roadmap.util.WorksheetResponseParser;
+import com.theokanning.openai.Usage;
+import com.theokanning.openai.completion.chat.ChatCompletionRequest;
+import com.theokanning.openai.completion.chat.ChatCompletionResult;
+import com.theokanning.openai.completion.chat.ChatMessage;
+import com.theokanning.openai.completion.chat.ChatMessageRole;
+import com.theokanning.openai.service.OpenAiService;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WorksheetService {
+
+    @Value("${openai.api.models.worksheet_generation.model}")
+    private String worksheetModel;
+
+    private final OpenAiService openAiService;
+    private final WorksheetPromptService promptService;
+    private final WorksheetResponseParser worksheetResponseParser;
+    private final DailyPlanRepository dailyPlanRepository;
+
+    @Async
+    @Transactional
+    public CompletableFuture<Void> generateAllWorksheets(Long roadmapId) {
+        return CompletableFuture.runAsync(() -> {
+            log.info("로드맵 ID: {}의 전체 학습지 생성 시작", roadmapId);
+
+            List<DailyPlan> allDailyPlans = dailyPlanRepository.findAllByWeeklyPlan_RoadMap_IdOrderByDayNumber(
+                    roadmapId);
+            List<List<DailyPlan>> groupedPlans = splitIntoGroups(allDailyPlans, 3);
+
+            for (List<DailyPlan> planGroup : groupedPlans) {
+                try {
+                    generateWorksheetForGroup(planGroup);
+                    // API 요청 제한을 고려한 대기 시간
+                    Thread.sleep(1000);
+                } catch (Exception e) {
+                    log.error("그룹 학습지 생성 중 오류 발생: {}일차 그룹, 오류: {}",
+                            planGroup.get(0).getDayNumber(), e.getMessage());
+                }
+            }
+
+            log.info("로드맵 ID: {}의 전체 학습지 생성 완료", roadmapId);
+        });
+    }
+
+    private List<List<DailyPlan>> splitIntoGroups(List<DailyPlan> allPlans, int groupSize) {
+        List<List<DailyPlan>> groups = new ArrayList<>();
+        for (int i = 0; i < allPlans.size(); i += groupSize) {
+            int end = Math.min(i + groupSize, allPlans.size());
+            groups.add(allPlans.subList(i, end));
+        }
+        return groups;
+    }
+
+    private void generateWorksheetForGroup(List<DailyPlan> planGroup) {
+        String prompt = promptService.createPrompt(planGroup);
+
+        ChatCompletionRequest completionRequest = ChatCompletionRequest.builder()
+                .model(worksheetModel)
+                .messages(List.of(new ChatMessage(ChatMessageRole.USER.value(), prompt)))
+                .temperature(0.7)
+                .maxTokens(2500)
+                .build();
+
+        try {
+            log.info("학습지 생성 API 호출 시작 - {} ~ {}일차",
+                    planGroup.get(0).getDayNumber(),
+                    planGroup.get(planGroup.size() - 1).getDayNumber());
+
+            ChatCompletionResult chatCompletion = openAiService.createChatCompletion(completionRequest);
+            String worksheetContent = chatCompletion.getChoices().get(0).getMessage().getContent();
+
+            updateDailyPlansWithWorksheet(planGroup, worksheetContent);
+            logTokenUsage(chatCompletion.getUsage());
+
+            log.info("학습지 생성 완료 - {} ~ {}일차",
+                    planGroup.get(0).getDayNumber(),
+                    planGroup.get(planGroup.size() - 1).getDayNumber());
+
+        } catch (Exception e) {
+            log.error("학습지 생성 중 오류 발생:", e);
+            throw new RuntimeException("학습지 생성 실패", e);
+        }
+    }
+
+    @Transactional
+    protected void updateDailyPlansWithWorksheet(List<DailyPlan> plans, String worksheetContent) {
+        Map<Integer, String> dayWorksheets = worksheetResponseParser.parseResponse(worksheetContent);
+
+        for (DailyPlan plan : plans) {
+            String worksheet = dayWorksheets.get(plan.getDayNumber());
+            if (worksheet != null) {
+                plan.updateWorkSheet(worksheet);
+                dailyPlanRepository.save(plan);
+                log.debug("{}일차 학습지 저장 완료", plan.getDayNumber());
+            } else {
+                log.warn("{}일차 학습지 내용이 없습니다", plan.getDayNumber());
+            }
+        }
+    }
+
+    private void logTokenUsage(Usage usage) {
+        if (usage != null) {
+            log.info("토큰 사용량 - Prompt: {}, Completion: {}, Total: {}",
+                    usage.getPromptTokens(),
+                    usage.getCompletionTokens(),
+                    usage.getTotalTokens());
+        } else {
+            log.warn("토큰 사용량 정보를 가져올 수 없습니다.");
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public long getWorksheetProgress(Long roadmapId) {
+        long totalPlans = dailyPlanRepository.countTotalDailyPlans(roadmapId);
+        long pendingPlans = dailyPlanRepository.countPendingWorksheets(roadmapId);
+        return ((totalPlans - pendingPlans) * 100) / totalPlans;
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/util/RoadmapResponseParser.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/util/RoadmapResponseParser.java
@@ -1,0 +1,66 @@
+package com.study.moya.ai_roadmap.util;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.study.moya.ai_roadmap.dto.response.WeeklyRoadmapResponse;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class RoadmapResponseParser {
+
+    private final ObjectMapper objectMapper;
+
+    public RoadmapResponseParser(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public WeeklyRoadmapResponse parseResponse(String apiResponse) {
+        try {
+            JsonNode rootNode = objectMapper.readTree(apiResponse);
+
+            List<WeeklyRoadmapResponse.WeeklyPlan> weeklyPlans = parseWeeklyPlans(rootNode.get("weeklyPlans"));
+            List<String> overallTips = objectMapper.convertValue(
+                    rootNode.get("overallTips"),
+                    new TypeReference<>() {}
+            );
+            String curriculumEvaluation = rootNode.get("curriculumEvaluation").asText();
+            String hasRestrictedTopics = rootNode.get("hasRestrictedTopics").asText();
+
+            return new WeeklyRoadmapResponse(weeklyPlans, overallTips, curriculumEvaluation, hasRestrictedTopics);
+        } catch (Exception e) {
+            log.error("Error parsing API response: {}", apiResponse, e);
+            throw new RuntimeException("Failed to parse API response", e);
+        }
+    }
+
+    private List<WeeklyRoadmapResponse.WeeklyPlan> parseWeeklyPlans(JsonNode weeklyPlansNode) {
+        List<WeeklyRoadmapResponse.WeeklyPlan> weeklyPlans = new ArrayList<>();
+
+        for (JsonNode weeklyPlanNode : weeklyPlansNode) {
+            int week = weeklyPlanNode.get("week").asInt();
+            String weeklyKeyword = weeklyPlanNode.get("weeklyKeyword").asText();
+            List<WeeklyRoadmapResponse.DailyPlan> dailyPlans = parseDailyPlans(weeklyPlanNode.get("dailyPlans"));
+
+            weeklyPlans.add(new WeeklyRoadmapResponse.WeeklyPlan(week, weeklyKeyword, dailyPlans));
+        }
+
+        return weeklyPlans;
+    }
+
+    private List<WeeklyRoadmapResponse.DailyPlan> parseDailyPlans(JsonNode dailyPlansNode) {
+        List<WeeklyRoadmapResponse.DailyPlan> dailyPlans = new ArrayList<>();
+
+        for (JsonNode dailyPlanNode : dailyPlansNode) {
+            int day = dailyPlanNode.get("day").asInt();
+            String dailyKeyword = dailyPlanNode.get("dailyKeyword").asText();
+            dailyPlans.add(new WeeklyRoadmapResponse.DailyPlan(day, dailyKeyword));
+        }
+
+        return dailyPlans;
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/util/WorksheetResponseParser.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/util/WorksheetResponseParser.java
@@ -1,0 +1,66 @@
+package com.study.moya.ai_roadmap.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WorksheetResponseParser {
+
+    private static final Pattern DAY_PATTERN = Pattern.compile(
+            "===\\s*DAY\\s*(\\d+)\\s*===\\s*([\\s\\S]*?)(?====\\s*DAY|$)");
+
+    public Map<Integer, String> parseResponse(String apiResponse) {
+        try {
+            Map<Integer, String> dayWorksheets = new HashMap<>();
+
+            // 특수 문자 및 불필요한 포맷 제거
+            apiResponse = cleanResponse(apiResponse);
+
+            Matcher matcher = DAY_PATTERN.matcher(apiResponse);
+            while (matcher.find()) {
+                int day = Integer.parseInt(matcher.group(1));
+                String content = matcher.group(2).trim();
+
+                // 내용이 의미 있는 길이를 가지고 있는지 확인
+                if (content.length() > 50) {  // 최소 길이 체크
+                    dayWorksheets.put(day, content);
+                    log.debug("Day {} 학습 가이드 파싱 완료 (길이: {})", day, content.length());
+                } else {
+                    log.warn("Day {} 학습 가이드 내용이 너무 짧습니다: {}", day, content);
+                }
+            }
+
+            if (dayWorksheets.isEmpty()) {
+                throw new IllegalStateException("파싱된 학습 가이드가 없습니다. 원본 응답: " + apiResponse);
+            }
+
+            return dayWorksheets;
+
+        } catch (Exception e) {
+            log.error("학습 가이드 파싱 중 오류 발생: {}", apiResponse, e);
+            throw new RuntimeException("학습 가이드 파싱 실패", e);
+        }
+    }
+
+    private String cleanResponse(String response) {
+        // 마크다운 코드 블록 제거
+        response = response.replaceAll("```.*?```", "");
+        // 마크다운 헤더 제거
+        response = response.replaceAll("#+ ", "");
+        // 불릿 포인트 제거
+        response = response.replaceAll("^[-*] ", "");
+        // 번호 매기기 제거
+        response = response.replaceAll("^\\d+\\. ", "");
+        // 여러 줄 공백을 한 줄로
+        response = response.replaceAll("\\n\\s*\\n", "\n");
+
+        return response.trim();
+    }
+}


### PR DESCRIPTION
# AI 스터디 로드맵 생성 서비스 구현
## 🔍 PR 개요
AI를 활용하여 학습자의 수준과 목표에 맞는 맞춤형 학습 로드맵을 생성하고, 일별 학습 워크시트를 제공하는 서비스를 구현했습니다.

## 📝 변경사항
### 로드맵 생성 기능 구현
- OpenAI API를 활용한 비동기 로드맵 생성 서비스 구현
- 로드맵, 주차별 계획, 일별 계획의 계층 구조 설계 및 구현
- 로드맵 생성 결과를 DB에 저장하는 기능 구현

### 학습 워크시트 생성 기능 구현
- 일별 학습 계획에 따른 워크시트 자동 생성 기능 구현
- 배치 처리를 통한 대량의 워크시트 생성 최적화
- API 요청 제한을 고려한 처리 로직 구현

### 카테고리 관리 기능 구현
- 계층형 카테고리 CRUD API 구현
- 카테고리 대량 처리 기능 구현
- 카테고리 계층 구조 조회 API 구현

## 🔗 관련 이슈
- Close #123 AI 로드맵 생성 기능 구현
- Close #124 학습 워크시트 생성 기능 구현
- Close #125 카테고리 관리 기능 구현

## ✅ 체크리스트
### 로컬 테스트
- [x] 로드맵 생성 기능 테스트 완료
- [x] 워크시트 생성 기능 테스트 완료
- [x] 카테고리 관리 기능 테스트 완료

### JPA 성능 최적화
- [x] 엔티티에 적절한 인덱스 추가
  - Category 테이블의 parent_id에 인덱스 추가
  - RoadMap 테이블의 category_id에 인덱스 추가
- [x] N+1 문제 해결
  - FetchType.LAZY 설정 및 필요한 경우에만 fetch join 사용
  - 카테고리 계층 조회 시 BatchSize 설정으로 최적화

### 캐시 정책
- [x] 캐시 적용 필요성 검토
  - 검토 결과: 카테고리 계층 구조에 캐시 적용 필요
  - 적용 방안: Spring Cache와 Redis를 활용한 카테고리 계층 구조 캐싱

### DB 스키마 변경
- [x] 테이블 생성/수정
```sql
CREATE TABLE categories (
    id BIGINT AUTO_INCREMENT PRIMARY KEY,
    name VARCHAR(255) NOT NULL,
    parent_id BIGINT,
    depth INT NOT NULL,
    created_at TIMESTAMP,
    updated_at TIMESTAMP,
    FOREIGN KEY (parent_id) REFERENCES categories(id)
);

CREATE INDEX idx_parent_id ON categories(parent_id);
```

### API 문서화
- [x] Controller에 @Tag 추가
- [x] API 설명 추가

## 🚨 주의사항
### 1. 설정 관련
- OpenAI API 키 설정 필요
- Redis 서버 설정 필요 (캐싱용)

### 2. 운영 관련
- OpenAI API 호출 제한 고려 필요
- 워크시트 생성은 비동기로 처리되므로 상태 모니터링 필요

### 3. 에러 처리
- OpenAI API 장애 시 재시도 로직 구현
- 비동기 처리 중 발생하는 예외는 로깅 후 관리자에게 알림

### 4. 확장 가이드
- 새로운 AI 모델 추가 시 RoadmapService 확장
- 카테고리 depth 제한은 현재 없으나 필요시 추가 가능