### PR TITLE
KAN-127 feat. MyPage 완료, logout과 refreshToken의 jwt 처리 단일화(차후 수정 필요)

### DIFF
--- a/back/moya/src/main/java/com/study/moya/member/domain/Member.java
+++ b/back/moya/src/main/java/com/study/moya/member/domain/Member.java
@@ -73,6 +73,9 @@ public class Member extends BaseEntity implements UserDetails {
     @Column(name = "personal_info_expiry_date")
     private LocalDateTime personalInfoExpiryDate;
 
+    @Column(length = 500)
+    private String introduction;
+
     @Embedded
     private PrivacyConsent privacyConsent;
 
@@ -185,6 +188,11 @@ public class Member extends BaseEntity implements UserDetails {
         if (this.status == MemberStatus.DORMANT) {
             this.status = MemberStatus.ACTIVE;
         }
+    }
+
+    public void updateIntroduction(String introduction) {
+        validateModifiable();
+        this.introduction = introduction;
     }
 
     public void convertToDormant() {

--- a/back/moya/src/main/java/com/study/moya/member/repository/MemberRepository.java
+++ b/back/moya/src/main/java/com/study/moya/member/repository/MemberRepository.java
@@ -2,6 +2,8 @@ package com.study.moya.member.repository;
 
 import com.study.moya.member.domain.Member;
 import java.util.Optional;
+
+import com.study.moya.member.domain.MemberStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -14,4 +16,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByNickname(String nickname);
 
+    boolean existsByNicknameAndStatusNot(String nickname, MemberStatus status);
 }

--- a/back/moya/src/main/java/com/study/moya/mypage/controller/MyPageController.java
+++ b/back/moya/src/main/java/com/study/moya/mypage/controller/MyPageController.java
@@ -1,0 +1,34 @@
+package com.study.moya.mypage.controller;
+
+import com.study.moya.global.api.ApiResponse;
+import com.study.moya.mypage.dto.MyPageResponse;
+import com.study.moya.mypage.dto.MyPageUpdateRequest;
+import com.study.moya.mypage.service.MyPageService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/mypage")
+public class MyPageController {
+    private final MyPageService myPageService;
+
+    @GetMapping
+    public ResponseEntity<MyPageResponse> getMyPage(@AuthenticationPrincipal String email) {
+        MyPageResponse response = myPageService.getMyPageInfo(email);
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping
+    public ResponseEntity<MyPageResponse> updateMyPage(
+            @AuthenticationPrincipal String email,
+            @Valid @RequestBody MyPageUpdateRequest request) {
+        MyPageResponse response = myPageService.updateMyPage(email, request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/mypage/dto/MyPageResponse.java
+++ b/back/moya/src/main/java/com/study/moya/mypage/dto/MyPageResponse.java
@@ -1,0 +1,24 @@
+package com.study.moya.mypage.dto;
+
+import com.study.moya.member.domain.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "마이페이지 응답")
+public record MyPageResponse(
+        @Schema(description = "닉네임", example = "모야")
+        String nickname,
+
+        @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg")
+        String profileImageUrl,
+
+        @Schema(description = "자기소개", example = "안녕하세요, 백엔드 개발자입니다.")
+        String introduction
+) {
+    public static MyPageResponse from(Member member) {
+        return new MyPageResponse(
+                member.getNickname(),
+                member.getProfileImageUrl(),
+                member.getIntroduction()
+        );
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/mypage/dto/MyPageUpdateRequest.java
+++ b/back/moya/src/main/java/com/study/moya/mypage/dto/MyPageUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.study.moya.mypage.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "마이페이지 수정 요청")
+public record MyPageUpdateRequest(
+        @Schema(description = "닉네임", example = "모야")
+        @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(min = 2, max = 30, message = "닉네임은 2자 이상 30자 이하여야 합니다.")
+        String nickname,
+
+        @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg")
+        String profileImageUrl,
+
+        @Schema(description = "자기소개", example = "안녕하세요, 백엔드 개발자입니다.")
+        @Size(max = 500, message = "자기소개는 500자 이하여야 합니다.")
+        String introduction
+) {}

--- a/back/moya/src/main/java/com/study/moya/mypage/exception/MyPageErrorCode.java
+++ b/back/moya/src/main/java/com/study/moya/mypage/exception/MyPageErrorCode.java
@@ -1,0 +1,27 @@
+package com.study.moya.mypage.exception;
+
+import com.study.moya.error.constants.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MyPageErrorCode implements ErrorCode {
+
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "001", "회원이 존재하지 않습니다."),
+    MEMBER_BLOCKED(HttpStatus.FORBIDDEN, "002", "차단된 회원입니다."),
+    MEMBER_WITHDRAWN(HttpStatus.FORBIDDEN, "003", "탈퇴한 회원입니다."),
+    MEMBER_NOT_MODIFIABLE(HttpStatus.BAD_REQUEST, "004", "회원 정보를 수정할 수 없는 상태입니다."),
+    DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "005", "이미 사용 중인 닉네임입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+    private static final String PREFIX = "MEMBER";
+
+    @Override
+    public String getFullCode() {
+        return PREFIX + "_" + code;
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/mypage/exception/MyPageException.java
+++ b/back/moya/src/main/java/com/study/moya/mypage/exception/MyPageException.java
@@ -1,0 +1,13 @@
+package com.study.moya.mypage.exception;
+
+import com.study.moya.error.exception.BaseException;
+
+public class MyPageException extends BaseException {
+    protected MyPageException(MyPageErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public static MyPageException of(MyPageErrorCode errorCode) {
+        return new MyPageException(errorCode);
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/mypage/service/MyPageService.java
+++ b/back/moya/src/main/java/com/study/moya/mypage/service/MyPageService.java
@@ -1,0 +1,47 @@
+package com.study.moya.mypage.service;
+
+import com.study.moya.error.constants.MemberErrorCode;
+import com.study.moya.error.exception.MemberException;
+import com.study.moya.member.domain.Member;
+import com.study.moya.member.domain.MemberStatus;
+import com.study.moya.member.repository.MemberRepository;
+import com.study.moya.mypage.dto.MyPageResponse;
+import com.study.moya.mypage.dto.MyPageUpdateRequest;
+import com.study.moya.mypage.exception.MyPageErrorCode;
+import com.study.moya.mypage.exception.MyPageException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MyPageService {
+    private final MemberRepository memberRepository;
+
+    public MyPageResponse getMyPageInfo(String email) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> MyPageException.of(MyPageErrorCode.MEMBER_NOT_FOUND));
+        return MyPageResponse.from(member);
+    }
+
+    @Transactional
+    public MyPageResponse updateMyPage(String email, MyPageUpdateRequest request) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> MyPageException.of(MyPageErrorCode.MEMBER_NOT_FOUND));
+
+        if(!member.getNickname().equals(request.nickname()) &&
+                memberRepository.existsByNicknameAndStatusNot(
+                        request.nickname(),
+                        MemberStatus.WITHDRAWN
+                )){
+            throw MyPageException.of(MyPageErrorCode.DUPLICATE_NICKNAME);
+        }
+        member.updateNickname(request.nickname());
+        member.updateProfileImage(request.profileImageUrl());
+        member.updateIntroduction(request.introduction());
+
+        return MyPageResponse.from(member);
+    }
+}


### PR DESCRIPTION
# {기능 이름}
Mypage 구현 완료
logout과 refreshToken의 jwt 처리 단일화 완료
(현재 username을 id 값이 아닌 email값을 사용하는 부분은 차후 수정이 필요하며 이때 코드 또한 수정이 필요하다)

Member - introduction(String) 생성
MemberRepository - existsByNicknameAndStatusNot  생성(닉네임 중복 여부 확인시에 사용)
JwtTokenProvider - extractEmail 생성 (getEmailFromOAuthToken메서드 대체)

## 🔍 PR 개요
<!--구현한 기능에 대해 간단히 설명해주세요.-->

## 📝 변경사항
<!--주요 변경사항을 항목별로 설명해주세요.-->
### 주요 기능 1 구현
- 


### 주요 기능 2 구현
- 

### 주요 기능 3 구현
- 

## 🔗 관련 이슈
<!--관련된 이슈를 연결해주세요.-->
- Close #100 


## ✅ 체크리스트
<!--각 항목을 체크하고 필요한 내용을 추가해주세요.-->
### 로컬 테스트
- [ ] 기능 1 테스트 완료
- [ ] 기능 2 테스트 완료
- [ ] 기능 3 테스트 완료

### JPA 성능 최적화
- [ ] 엔티티에 적절한 인덱스 추가
  - 설명 추가
- [ ] N+1 문제 해결
  - 해결 방법 설명

### 캐시 정책
- [ ] 캐시 적용 필요성 검토
  - 검토 결과
  - 적용 방안

### DB 스키마 변경
- [ ] 테이블 생성/수정
```sql
-- SQL 구문 작성
```

### API 문서화
- [ ] Controller에 @Tag 추가
- [ ] API 설명 추가

## 🚨 주의사항
### 1. 설정 관련
<!--필요한 설정이나 환경 변수에 대해 설명해주세요.-->
-

### 2. 운영 관련
<!--운영 시 주의해야 할 사항을 설명해주세요.-->
- 

### 3. 에러 처리
<!--에러 처리 방식과 주의사항을 설명해주세요.-->
- 

### 4. 확장 가이드
<!--코드 확장 시 참고할 사항을 설명해주세요.-->
- 
