### PR TITLE
KAN-132 feat. coupon + swagger

### DIFF
--- a/back/moya/src/main/java/com/study/moya/coupon/controller/CouponController.java
+++ b/back/moya/src/main/java/com/study/moya/coupon/controller/CouponController.java
@@ -1,0 +1,121 @@
+package com.study.moya.coupon.controller;
+
+import com.study.moya.coupon.dto.CouponResponse;
+import com.study.moya.swagger.annotation.SwaggerErrorDescription;
+import com.study.moya.swagger.annotation.SwaggerErrorDescriptions;
+import com.study.moya.swagger.annotation.SwaggerSuccessResponse;
+import com.study.moya.coupon.dto.CouponBatchRequest;
+import com.study.moya.coupon.dto.CouponIssueRequest;
+import com.study.moya.coupon.dto.CouponUseRequest;
+import com.study.moya.coupon.exception.CouponErrorCode;
+import com.study.moya.coupon.service.CouponService;
+import com.study.moya.global.api.ApiResponse;
+import com.study.moya.global.config.security.SecurityHeadersConfig;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/coupons")
+@Tag(name = "Coupon", description = "쿠폰 관련 API")
+public class CouponController {
+
+    private final CouponService couponService;
+    private final SecurityHeadersConfig securityHeadersConfig;
+
+
+    /**
+     * 쿠폰 발급
+     */
+    @Operation(summary = "쿠폰 발급", description = "회원에게 쿠폰을 발급합니다.")
+    @SwaggerSuccessResponse(status = 201, name = "쿠폰 발급이 완료됐습니다")
+    @SwaggerErrorDescriptions({
+            @SwaggerErrorDescription(name = "발급 가능한 쿠폰 없음", value = CouponErrorCode.class, code = "NO_COUPON_AVAILABLE"),
+            @SwaggerErrorDescription(name = "회원 찾을 수 없음", value = CouponErrorCode.class, code = "MEMBER_NOT_FOUND"),
+            @SwaggerErrorDescription(name = "쿠폰 발급 실패", description = "최대 재시도 횟수 초과", value = CouponErrorCode.class, code = "ISSUE_FAILED"),
+            @SwaggerErrorDescription(name = "이미 발급된 쿠폰", value = CouponErrorCode.class, code = "ALREADY_USED_COUPON"),
+            @SwaggerErrorDescription(name = "쿠폰 발급 처리 중 오류", description = "동시성 처리 중 발생한 오류", value = CouponErrorCode.class, code = "COUPON_ISSUE_LOCK_ACQUISITION_FAILED")
+    })
+    @PostMapping
+    public ResponseEntity<ApiResponse<String>> issueCoupon(
+            @AuthenticationPrincipal Long memberId,
+            @RequestBody CouponIssueRequest request) {
+        couponService.issueCoupon(memberId, request.getCouponType());
+        return securityHeadersConfig.addSecurityHeaders(ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.of("쿠폰 발급이 완료됐습니다")));
+    }
+
+    /**
+     * 쿠폰 사용
+     */
+    @Operation(summary = "쿠폰 사용", description = "회원의 보유 쿠폰을 사용 처리합니다. 쿠폰 사용 후 취소는 불가능합니다.")
+    @SwaggerSuccessResponse(
+            name = "쿠폰 사용이 완료됐습니다"
+    )
+    @SwaggerErrorDescriptions({
+            @SwaggerErrorDescription(
+                    name = "쿠폰 없음",
+                    value = CouponErrorCode.class,
+                    code = "COUPON_NOT_FOUND"
+            ),
+            @SwaggerErrorDescription(
+                    name = "만료된 쿠폰",
+                    value = CouponErrorCode.class,
+                    code = "EXPIRED_COUPON"
+            ),
+            @SwaggerErrorDescription(
+                    name = "이미 사용된 쿠폰",
+                    value = CouponErrorCode.class,
+                    code = "ALREADY_USED_COUPON"
+            ),
+            @SwaggerErrorDescription(
+                    name = "쿠폰 사용 처리 중 오류",
+                    description = "동시성 처리 중 발생한 오류",
+                    value = CouponErrorCode.class,
+                    code = "COUPON_LOCK_ACQUISITION_FAILED"
+            )
+    })
+    @PatchMapping("/use")
+    public ResponseEntity<ApiResponse<String>> useCoupon(
+            @AuthenticationPrincipal Long memberId,
+            @RequestBody CouponUseRequest request
+            ) {
+        couponService.useCoupon(memberId, request.getCouponType());
+        return securityHeadersConfig.addSecurityHeaders(ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.of("쿠폰 사용이 완료됐습니다")));
+    }
+
+    /**
+     * 쿠폰 생성
+     */
+    @PostMapping("/batch")
+    @Operation(summary = "쿠폰 일괄 생성", description = "관리자가 쿠폰을 일괄 생성합니다. 생성된 쿠폰은 발급 대기 상태가 됩니다.")
+    @SwaggerSuccessResponse(
+            name = "쿠폰 생성이 완료됐습니다",
+            value = CouponResponse.class,
+            status = 201
+            )
+    @SwaggerErrorDescriptions({
+            @SwaggerErrorDescription(
+                    name = "잘못된 유효기간",
+                    description = "유효기간이 현재 시간보다 이전",
+                    value = CouponErrorCode.class,
+                    code = "INVALID_EXPIRATION_DATE"
+            )
+    })
+    public ResponseEntity<ApiResponse<CouponResponse>> createCoupons(
+            @RequestBody CouponBatchRequest request) {
+        CouponResponse responses = couponService.createCoupons(request.getCount(), request.getCouponType(), request.getExpirationDate());
+        return securityHeadersConfig.addSecurityHeaders(ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.of(responses)));
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/coupon/domain/Coupon.java
+++ b/back/moya/src/main/java/com/study/moya/coupon/domain/Coupon.java
@@ -1,14 +1,9 @@
-package com.study.moya.cu;
+package com.study.moya.coupon.domain;
 
 import com.study.moya.BaseEntity;
 import com.study.moya.member.domain.Member;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.*;
+
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -24,9 +19,15 @@ public class Coupon extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Version
+    private Long version;
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @Enumerated(EnumType.STRING)
+    private CouponType couponType;
 
     private LocalDateTime expirationDate;
 
@@ -35,8 +36,9 @@ public class Coupon extends BaseEntity {
     private LocalDateTime usedAt;
 
     @Builder
-    private Coupon(Member member, LocalDateTime expirationDate) {
+    private Coupon(Member member, CouponType couponType, LocalDateTime expirationDate) {
         this.member = member;
+        this.couponType = couponType;
         this.expirationDate = expirationDate;
         this.isUsed = false;
     }
@@ -60,8 +62,22 @@ public class Coupon extends BaseEntity {
             throw new IllegalStateException("이미 사용된 쿠폰입니다.");
         }
     }
+    public void assignMember(Member member) {
+        validateNotAssigned();
+        this.member = member;
+    }
+
+    private void validateNotAssigned() {
+        if (this.member != null) {
+            throw new IllegalStateException("이미 할당된 쿠폰입니다.");
+        }
+    }
 
     public boolean isExpired() {
         return LocalDateTime.now().isAfter(expirationDate);
+    }
+
+    public int getDiscountPercent() {
+        return this.couponType.getTokenAmount();
     }
 }

--- a/back/moya/src/main/java/com/study/moya/coupon/domain/CouponType.java
+++ b/back/moya/src/main/java/com/study/moya/coupon/domain/CouponType.java
@@ -1,0 +1,16 @@
+package com.study.moya.coupon.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CouponType {
+    WELCOME("신규 가입 환영 쿠폰", 10),
+    BIRTHDAY("생일 축하 쿠폰", 15),
+    HOLIDAY("공휴일 특별 쿠폰", 20),
+    VIP("VIP 전용 쿠폰", 25);
+
+    private final String description;
+    private final int tokenAmount;
+}

--- a/back/moya/src/main/java/com/study/moya/coupon/dto/CouponBatchRequest.java
+++ b/back/moya/src/main/java/com/study/moya/coupon/dto/CouponBatchRequest.java
@@ -1,0 +1,25 @@
+package com.study.moya.coupon.dto;
+
+import com.study.moya.coupon.domain.CouponType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Schema(description = "쿠폰 생성 요청")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CouponBatchRequest {
+    @Schema(description = "쿠폰 유형", example = "WELCOME", required = true)
+    private CouponType couponType;
+
+    @Schema(description = "생성할 쿠폰 수량", example = "100", required = true, minimum = "1", maximum = "?")
+    private int count;
+
+    @NotNull(message = "유효기간은 필수입니다")
+    @Schema(description = "쿠폰 만료일시", example = "2024-12-31T23:59:59", required = true)
+    private LocalDateTime expirationDate;
+}

--- a/back/moya/src/main/java/com/study/moya/coupon/dto/CouponIssueRequest.java
+++ b/back/moya/src/main/java/com/study/moya/coupon/dto/CouponIssueRequest.java
@@ -1,0 +1,15 @@
+package com.study.moya.coupon.dto;
+
+import com.study.moya.coupon.domain.CouponType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "쿠폰 발급 요청")
+public class CouponIssueRequest {
+    @Schema(description = "쿠폰 유형", example = "WELCOME", required = true)
+    private CouponType couponType;
+}

--- a/back/moya/src/main/java/com/study/moya/coupon/dto/CouponResponse.java
+++ b/back/moya/src/main/java/com/study/moya/coupon/dto/CouponResponse.java
@@ -1,0 +1,34 @@
+package com.study.moya.coupon.dto;
+
+import com.study.moya.coupon.domain.Coupon;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "쿠폰 발급 응답")
+public class CouponResponse {
+    @Schema(description = "쿠폰 ID", example = "1")
+    private Long couponId;
+
+    @Schema(description = "회원 ID", example = "100")
+    private Long memberId;
+
+    @Schema(description = "쿠폰 만료일시", example = "2024-12-31T23:59:59")
+    private LocalDateTime expirationDate;
+
+    @Schema(description = "쿠폰 사용 여부", example = "false")
+    private boolean isUsed;
+
+    public static CouponResponse from(Coupon coupon) {
+        return CouponResponse.builder()
+                .couponId(coupon.getId())
+                .memberId(coupon.getMember().getId())
+                .expirationDate(coupon.getExpirationDate())
+                .isUsed(coupon.isUsed())
+                .build();
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/coupon/dto/CouponUseRequest.java
+++ b/back/moya/src/main/java/com/study/moya/coupon/dto/CouponUseRequest.java
@@ -1,0 +1,15 @@
+package com.study.moya.coupon.dto;
+
+import com.study.moya.coupon.domain.CouponType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "쿠폰 사용 요청")
+public class CouponUseRequest {
+    @Schema(description = "쿠폰 유형", example = "WELCOME", required = true)
+    private CouponType couponType;
+}

--- a/back/moya/src/main/java/com/study/moya/coupon/exception/CouponErrorCode.java
+++ b/back/moya/src/main/java/com/study/moya/coupon/exception/CouponErrorCode.java
@@ -1,0 +1,51 @@
+package com.study.moya.coupon.exception;
+
+import com.study.moya.error.constants.ErrorCode;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CouponErrorCode implements ErrorCode {
+    @Schema(description = "쿠폰이 존재하지 않음")
+    COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "001", "쿠폰이 존재하지 않습니다."),
+
+    @Schema(description = "만료된 쿠폰")
+    EXPIRED_COUPON(HttpStatus.BAD_REQUEST, "002", "만료된 쿠폰입니다."),
+
+    @Schema(description = "사용된 쿠폰")
+    ALREADY_USED_COUPON(HttpStatus.BAD_REQUEST, "003", "이미 사용된 쿠폰입니다."),
+
+    @Schema(description = "쿠폰의 사용자가 아님")
+    INVALID_COUPON_OWNER(HttpStatus.FORBIDDEN, "004", "쿠폰의 소유자가 아닙니다."),
+
+    @Schema(description = "쿠폰 사용 처리 중 오류 발생")
+    COUPON_LOCK_ACQUISITION_FAILED(HttpStatus.CONFLICT, "005", "쿠폰 사용 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요."),
+
+    @Schema(description = "발급 가능한 쿠폰 없음")
+    NO_COUPON_AVAILABLE(HttpStatus.BAD_REQUEST, "006", "발급 가능한 쿠폰이 없습니다."),
+
+    @Schema(description = "회원을 찾을 수 없음")
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "007", "회원을 찾을 수 없습니다."),
+
+    @Schema(description = "쿠폰 발급 처리 중 오류 발생")
+    COUPON_ISSUE_LOCK_ACQUISITION_FAILED(HttpStatus.CONFLICT, "008", "쿠폰 발급 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요."),
+
+    @Schema(description = "쿠폰 발급 실패")
+    ISSUE_FAILED(HttpStatus.CONFLICT, "009", "쿠폰 발급에 실패했습니다."),
+
+    @Schema(description = "유효기간이 현재 시간보다 이전")
+    INVALID_EXPIRATION_DATE(HttpStatus.BAD_REQUEST, "010", "유효기간이 현재 시간보다 이전입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+    private static final String PREFIX = "COUPON";
+
+    @Override
+    public String getFullCode() {
+        return PREFIX + "_" + code;
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/coupon/exception/CouponException.java
+++ b/back/moya/src/main/java/com/study/moya/coupon/exception/CouponException.java
@@ -1,0 +1,14 @@
+package com.study.moya.coupon.exception;
+
+import com.study.moya.error.exception.BaseException;
+
+public class CouponException extends BaseException {
+
+    protected CouponException(CouponErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public static CouponException of(CouponErrorCode errorCode) {
+        return new CouponException(errorCode);
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/coupon/repository/CouponRepository.java
+++ b/back/moya/src/main/java/com/study/moya/coupon/repository/CouponRepository.java
@@ -1,0 +1,27 @@
+package com.study.moya.coupon.repository;
+
+import com.study.moya.coupon.domain.Coupon;
+import com.study.moya.coupon.domain.CouponType;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.QueryHints;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface CouponRepository extends JpaRepository<Coupon, Long> {
+    boolean existsByMemberIdAndCouponType(Long memberId, CouponType couponType);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({@QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000")})
+    Optional<Coupon> findByMemberIdAndCouponType(Long memberId, CouponType couponType);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({@QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000")})
+    Optional<Coupon> findFirstByMemberIsNullAndCouponTypeAndExpirationDateGreaterThanOrderByIdAsc(CouponType couponType, LocalDateTime currentTime);
+
+    long countByMemberIsNotNull();
+    int countByMemberId(Long id);
+}

--- a/back/moya/src/main/java/com/study/moya/coupon/service/CouponService.java
+++ b/back/moya/src/main/java/com/study/moya/coupon/service/CouponService.java
@@ -1,0 +1,111 @@
+package com.study.moya.coupon.service;
+
+import com.study.moya.coupon.domain.Coupon;
+import com.study.moya.coupon.domain.CouponType;
+import com.study.moya.coupon.dto.CouponResponse;
+import com.study.moya.coupon.exception.CouponErrorCode;
+import com.study.moya.coupon.exception.CouponException;
+import com.study.moya.coupon.repository.CouponRepository;
+import com.study.moya.member.domain.Member;
+import com.study.moya.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CouponService {
+
+    private final CouponRepository couponRepository;
+    private final MemberRepository memberRepository;
+
+    /**
+     * 이미 발급된 쿠폰을 사용하는 기능
+     */
+    @Transactional
+    public void useCoupon(Long memberId,  CouponType couponType) {
+        log.info("인증된 사용자의 쿠폰 사용 시도 - 멤버ID: {}, 쿠폰타입: {}", memberId, couponType);
+
+        getMember(memberId);
+
+        Coupon coupon = couponRepository.findByMemberIdAndCouponType(memberId, couponType)
+                .orElseThrow(() -> CouponException.of(CouponErrorCode.COUPON_NOT_FOUND));
+        try {
+            coupon.use();
+        } catch (IllegalStateException e) {
+            handleCouponUsageException(e);
+        }
+        log.info("쿠폰 사용 완료 - 멤버ID: {}, 쿠폰ID: {}, 쿠폰타입: {}", memberId, coupon.getId(), couponType);
+    }
+
+    /**
+     * 새로운 쿠폰을 사용자에게 발급
+     */
+    @Transactional
+    public void issueCoupon(Long memberId, CouponType couponType) {
+        log.info("쿠폰 발급 시도 - 멤버ID: {}, 쿠폰타입: {}", memberId, couponType);
+
+        if (couponRepository.existsByMemberIdAndCouponType(memberId, couponType)) {
+            throw CouponException.of(CouponErrorCode.ALREADY_USED_COUPON);
+        }
+
+        Member member = getMember(memberId);
+
+        Coupon coupon = couponRepository
+                .findFirstByMemberIsNullAndCouponTypeAndExpirationDateGreaterThanOrderByIdAsc(
+                        couponType, LocalDateTime.now())
+                .orElseThrow(() -> CouponException.of(CouponErrorCode.NO_COUPON_AVAILABLE));
+
+        coupon.assignMember(member);
+        log.info("쿠폰 발급 성공 - 멤버ID: {}, 쿠폰ID: {}", memberId, coupon.getId());
+    }
+
+    /**
+     * 관리자용 쿠폰 생성 메소드
+     */
+    @Transactional
+    public CouponResponse createCoupons(int count, CouponType couponType, LocalDateTime expirationDate) {
+        log.info("새로운 {} 쿠폰 {} 개 생성 시도", couponType, count);
+
+        if (expirationDate.isBefore(LocalDateTime.now())) {
+            throw CouponException.of(CouponErrorCode.INVALID_EXPIRATION_DATE);
+        }
+        List<Coupon> coupons = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            coupons.add(Coupon.builder()
+                    .couponType(couponType)
+                    .expirationDate(LocalDateTime.now().plusDays(30))
+                    .build());
+        }
+        List<Coupon> savedCoupons = couponRepository.saveAll(coupons);
+        log.info("새로운 {} 쿠폰 {} 개 생성 완료", couponType, count);
+        return CouponResponse.from(savedCoupons.get(0));
+    }
+
+    /**
+     * 쿠폰 사용 중 발생하는 예외를 처리하는 내부 메서드
+     */
+    private void handleCouponUsageException(IllegalStateException e) {
+        if (e.getMessage().contains("만료된")) {
+            throw CouponException.of(CouponErrorCode.EXPIRED_COUPON);
+        } else if (e.getMessage().contains("이미 사용된")) {
+            throw CouponException.of(CouponErrorCode.ALREADY_USED_COUPON);
+        }
+        throw e;
+    }
+
+    /**
+     * 회원 조회
+     */
+    private Member getMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> CouponException.of(CouponErrorCode.MEMBER_NOT_FOUND));
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/global/api/ApiError.java
+++ b/back/moya/src/main/java/com/study/moya/global/api/ApiError.java
@@ -2,13 +2,21 @@ package com.study.moya.global.api;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.Map;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "API 에러 정보")
 class ApiError {
+    @Schema(description = "에러 코드", example = "COMMON_001")
     private final String code;
+
+    @Schema(description = "에러 메시지", example = "잘못된 입력값입니다")
     private final String message;
+
+    @Schema(description = "추가 에러 정보")
     private final Map<String, Object> details;
 
     private ApiError(String code, String message, Map<String, Object> details) {

--- a/back/moya/src/main/java/com/study/moya/global/api/ApiResponse.java
+++ b/back/moya/src/main/java/com/study/moya/global/api/ApiResponse.java
@@ -4,16 +4,26 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.study.moya.error.exception.BaseException;
 import java.util.List;
 import java.util.Map;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "API 응답")
 public class ApiResponse<T> {
+    @Schema(description = "HTTP 상태 코드", example = "200")
     private final int status;
+
+    @Schema(description = "응답 데이터")
     private final T data;
+
+    @Schema(description = "페이지네이션 정보")
     private final PageInfo pagination;
+
+    @Schema(description = "에러 정보")
     private final ApiError error;
 
 

--- a/back/moya/src/test/java/com/study/moya/coupon/CouponTest.java
+++ b/back/moya/src/test/java/com/study/moya/coupon/CouponTest.java
@@ -1,0 +1,192 @@
+package com.study.moya.coupon;
+
+import com.study.moya.coupon.domain.Coupon;
+import com.study.moya.coupon.domain.CouponType;
+import com.study.moya.coupon.repository.CouponRepository;
+import com.study.moya.coupon.service.CouponService;
+import com.study.moya.member.domain.Member;
+import com.study.moya.member.domain.MemberStatus;
+import com.study.moya.member.domain.Role;
+import com.study.moya.member.repository.MemberRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Slf4j
+public class CouponTest {
+    @Autowired
+    private CouponService couponService;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private List<Member> testMembers;
+    private static final int TOTAL_TEST_MEMBERS = 1000;
+
+    @BeforeEach
+    @Transactional
+    void setUp() {
+        // 테스트 시작 전 기존 데이터 정리
+        couponRepository.deleteAll();
+        memberRepository.deleteAll();
+
+        // 테스트용 멤버 200명 생성
+        testMembers = new ArrayList<>();
+        for (int i = 0; i < TOTAL_TEST_MEMBERS; i++) {
+            testMembers.add(memberRepository.save(Member.builder()
+                    .email("test" + i + "@example.com")
+                    .password("password")
+                    .nickname("testUser" + i)
+                    .providerId("test_provider_" + i)
+                    .roles(new HashSet<>(Arrays.asList(Role.USER)))
+                    .status(MemberStatus.ACTIVE)
+                    .termsAgreed(true)
+                    .privacyPolicyAgreed(true)
+                    .marketingAgreed(false)
+                    .build()));
+        }
+    }
+
+    @AfterEach
+    @Transactional
+    void cleanup() {
+        couponRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("낙관적 락: 200명이 동시에 50개의 쿠폰을 선착순으로 발급받기 시도")
+    void concurrentCouponIssueWithOptimisticLockTest() throws InterruptedException {
+        // given
+        int totalCoupons = 200;
+
+        // 쿠폰 생성
+        for (int i = 0; i < totalCoupons; i++) {
+            couponRepository.save(Coupon.builder()
+                    .expirationDate(LocalDateTime.now().plusDays(7))
+                    .couponType(CouponType.WELCOME)
+                    .build());
+        }
+
+        log.info("테스트 시작 - 생성된 멤버 수: {}, 생성된 쿠폰 수: {}",
+                memberRepository.count(), couponRepository.count());
+
+        int threadCount = TOTAL_TEST_MEMBERS;
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            final int index = i;
+            executorService.submit(() -> {
+                try {
+                    couponService.issueCoupon(testMembers.get(index).getId(), CouponType.WELCOME);
+                    log.info("쿠폰 발급 성공 - 멤버 ID: {}", testMembers.get(index).getId());
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    log.info("쿠폰 발급 실패 - 멤버 ID: {}, 에러: {}",
+                            testMembers.get(index).getId(), e.getMessage());
+                    failCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        // then
+        latch.await();
+        executorService.shutdown();
+
+        Long issuedCouponsCount = couponRepository.countByMemberIsNotNull();
+        log.info("테스트 결과 - 발급된 쿠폰 수: {}, 성공: {}, 실패: {}",
+                issuedCouponsCount, successCount.get(), failCount.get());
+
+        // 검증
+        assertThat(successCount.get()).isEqualTo(totalCoupons);
+        assertThat(issuedCouponsCount).isEqualTo(totalCoupons);
+
+        // 중복 발급 검증
+        long membersWithMultipleCoupons = testMembers.stream()
+                .filter(member -> couponRepository.countByMemberId(member.getId()) > 1)
+                .count();
+        assertThat(membersWithMultipleCoupons).isZero();
+    }
+
+    @Test
+    @DisplayName("낙관적 락: 200명의 사용자가 동시에 쿠폰 사용 시도시 단 한명만 성공해야 한다")
+    void concurrentCouponUseWithOptimisticLockTest() throws InterruptedException {
+        // given
+        Member testMember = testMembers.get(0);
+        Coupon coupon = couponRepository.save(Coupon.builder()
+                .expirationDate(LocalDateTime.now().plusDays(7))
+                .couponType(CouponType.WELCOME)
+                .member(testMember)
+                .build());
+
+        log.info("테스트 시작 - 쿠폰 ID: {}, 할당된 멤버 ID: {}",
+                coupon.getId(), testMember.getId());
+
+        int threadCount = TOTAL_TEST_MEMBERS;
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    couponService.useCoupon(testMember.getId(), CouponType.WELCOME);
+                    log.info("쿠폰 사용 성공 - 멤버 ID: {}", testMember.getId());
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    log.info("쿠폰 사용 실패 - 멤버 ID: {}, 에러: {}",
+                            testMember.getId(), e.getMessage());
+                    failCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        // then
+        latch.await();
+        executorService.shutdown();
+
+        log.info("테스트 완료 - 성공: {}, 실패: {}",
+                successCount.get(), failCount.get());
+
+        // 검증
+        assertThat(successCount.get()).isEqualTo(1);
+        assertThat(failCount.get()).isEqualTo(threadCount - 1);
+
+        // DB 상태 확인
+        Coupon finalCoupon = couponRepository.findById(coupon.getId()).orElseThrow();
+        assertThat(finalCoupon.isUsed()).isTrue();
+    }
+}


### PR DESCRIPTION
쿠폰 관리 시스템 구현
🔍 PR 개요
쿠폰 발급, 사용, 일괄 생성 등 쿠폰 관리를 위한 핵심 기능을 구현했습니다. 동시성 문제를 고려한 설계와 예외 처리를 포함하고 있습니다.
📝 변경사항
쿠폰 도메인 구현

Coupon 엔티티 설계 및 구현
쿠폰 타입별 할인율 설정 (WELCOME: 10%, BIRTHDAY: 15%, HOLIDAY: 20%, VIP: 25%)
쿠폰의 상태 관리 (발급 대기, 사용 여부, 만료 여부)

쿠폰 발급/사용 기능 구현

회원별 쿠폰 발급 API 구현
쿠폰 사용 처리 API 구현
관리자용 쿠폰 일괄 생성 API 구현

동시성 제어 구현

Pessimistic Lock을 통한 동시성 제어
트랜잭션 타임아웃 설정 (3초)
Version 칼럼을 통한 Optimistic Lock 구현

🔗 관련 이슈

Close #123 쿠폰 관리 시스템 구현

✅ 체크리스트
로컬 테스트

 쿠폰 발급 기능 테스트 완료
 쿠폰 사용 기능 테스트 완료
 쿠폰 일괄 생성 기능 테스트 완료

JPA 성능 최적화

 엔티티에 적절한 인덱스 추가

member_id와 coupon_type에 복합 인덱스 추가로 조회 성능 최적화


 N+1 문제 해결

Member 엔티티 조회 시 FetchType.LAZY 설정
필요한 경우에만 member 정보 조회



캐시 정책

 캐시 적용 필요성 검토

검토 결과: 쿠폰 사용/발급은 실시간 정합성이 중요하여 캐시 미적용
추후 쿠폰 조회 API 구현 시 캐시 적용 검토 필요



DB 스키마 변경

 테이블 생성

sqlCopyCREATE TABLE coupon (
    id BIGINT AUTO_INCREMENT PRIMARY KEY,
    version BIGINT,
    member_id BIGINT,
    coupon_type VARCHAR(20),
    expiration_date DATETIME,
    is_used BOOLEAN,
    used_at DATETIME,
    created_at DATETIME,
    updated_at DATETIME,
    FOREIGN KEY (member_id) REFERENCES member(id)
);

CREATE INDEX idx_member_coupon_type ON coupon(member_id, coupon_type);
API 문서화

 Controller에 @Tag 추가
 API 설명 추가

🚨 주의사항
1. 설정 관련

JPA Lock 타임아웃 설정 필요 (persistence.xml 또는 application.yml)
트랜잭션 타임아웃 설정 확인

2. 운영 관련

쿠폰 발급/사용 시 동시성 문제 모니터링 필요
만료된 쿠폰 처리를 위한 배치 작업 구현 필요

3. 에러 처리

쿠폰 관련 예외는 CouponException으로 통합 관리
에러 코드와 메시지는 CouponErrorCode에서 중앙 관리

4. 확장 가이드

신규 쿠폰 타입 추가 시 CouponType enum에 추가
쿠폰 정책 변경 시 Coupon 엔티티의 비즈니스 로직 수정