### PR TITLE
KAN-132 feat. coupon + swagger + annotation

### DIFF
--- a/back/moya/src/main/java/com/study/moya/global/config/OpenApiConfig.java
+++ b/back/moya/src/main/java/com/study/moya/global/config/OpenApiConfig.java
@@ -1,11 +1,26 @@
 package com.study.moya.global.config;
 
+import com.study.moya.swagger.annotation.SwaggerErrorDescription;
+import com.study.moya.swagger.annotation.SwaggerErrorDescriptions;
+import com.study.moya.swagger.annotation.SwaggerSuccessResponse;
+import com.study.moya.error.constants.ErrorCode;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.servers.Server;
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.HandlerMethod;
+
+import java.util.Map;
 
 @OpenAPIDefinition(
         servers = {
@@ -19,8 +34,119 @@ public class OpenApiConfig {
     @Bean
     public OpenAPI usersMicroserviceOpenAPI() {
         return new OpenAPI()
-                .info(new Info().title("Team S API")
-                        .description("API Description")
-                        .version("1.0"));
+                .components(new Components()
+                        // JWT 인증 스키마 설정
+                        .addSecuritySchemes("bearer-key",
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")))
+                .info(new Info()
+                        .title("Team S API")
+                        .description("Team S의 API 명세서입니다.")
+                        .version("1.0.0"));
+    }
+
+    @Bean
+    public OperationCustomizer customGlobalHeaders() {
+        return (Operation operation, HandlerMethod handlerMethod) -> {
+            operation.getResponses().clear();
+
+            SwaggerSuccessResponse successResponse =
+                    handlerMethod.getMethodAnnotation(SwaggerSuccessResponse.class);
+
+            if (successResponse != null) {
+                String statusCode = String.valueOf(successResponse.status());
+                ApiResponse response = new ApiResponse()
+                        .description(successResponse.name().isEmpty() ?
+                                "Success" : successResponse.name());
+
+                if (successResponse.value() != Void.class) {
+                    // 응답 스키마 생성 (항상 ApiResponse 래퍼 사용)
+                    Schema<?> dtoSchema = new Schema<>()
+                            .$ref("#/components/schemas/" +
+                                    successResponse.value().getSimpleName());
+
+                    Schema<?> responseSchema = new Schema<>()
+                            .type("object")
+                            .addProperty("status", new Schema<>()
+                                    .type("integer")
+                                    .example(successResponse.status()))
+                            .addProperty("data", dtoSchema);
+
+                    response.content(new Content()
+                            .addMediaType("application/json",
+                                    new MediaType()
+                                            .schema(responseSchema)));
+                } else {
+                    // 문자열 응답 처리
+                    response.content(new Content()
+                            .addMediaType("application/json",
+                                    new MediaType().schema(new Schema<>()
+                                            .type("object")
+                                            .addProperty("status", new Schema<>()
+                                                    .type("integer")
+                                                    .example(successResponse.status()))
+                                            .addProperty("data", new Schema<>()
+                                                    .type("string")
+                                                    .example(successResponse.name())))));
+                }
+
+                operation.getResponses().addApiResponse(statusCode, response);
+            }
+
+            SwaggerErrorDescriptions errorExplanations =
+                    handlerMethod.getMethodAnnotation(SwaggerErrorDescriptions.class);
+            if (errorExplanations != null) {
+                for (SwaggerErrorDescription explanation : errorExplanations.value()) {
+                    addErrorResponse(operation, explanation);
+                }
+            }
+
+            return operation;
+        };
+    }
+
+    private void addErrorResponse(Operation operation, SwaggerErrorDescription explanation) {
+        try {
+            ErrorCode errorCode = (ErrorCode) findEnumConstant(explanation.value(), explanation.code());
+            String statusCode = String.valueOf(errorCode.getStatus().value());
+
+            // 에러 코드를 포함한 고유한 응답 키 생성
+            String responseKey = statusCode + "_" + errorCode.getFullCode();
+
+            ApiResponse response = new ApiResponse()
+                    .description(explanation.name() +
+                            (explanation.description().isEmpty() ? "" : " - " + explanation.description()))
+                    .content(new Content()
+                            .addMediaType("application/json",
+                                    new MediaType().schema(new Schema<>()
+                                            .example(createErrorExample(errorCode)))));
+
+            operation.getResponses().addApiResponse(responseKey, response);
+        } catch (Exception e) {
+            throw new IllegalArgumentException(
+                    "Error processing ErrorCode enum: " + explanation.value() + "." + explanation.code(),
+                    e
+            );
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Enum<? extends ErrorCode> findEnumConstant(
+            Class<? extends Enum<? extends ErrorCode>> enumClass,
+            String constantName
+    ) {
+        return Enum.valueOf((Class<? extends Enum>) enumClass, constantName);
+    }
+
+    private Object createErrorExample(ErrorCode errorCode) {
+        return Map.of(
+                "status", errorCode.getStatus().value(),
+                "error", Map.of(
+                        "code", errorCode.getFullCode(),
+                        "message", errorCode.getMessage()
+                )
+        );
     }
 }

--- a/back/moya/src/main/java/com/study/moya/swagger/annotation/SwaggerErrorDescription.java
+++ b/back/moya/src/main/java/com/study/moya/swagger/annotation/SwaggerErrorDescription.java
@@ -1,0 +1,17 @@
+package com.study.moya.swagger.annotation;
+
+import com.study.moya.error.constants.ErrorCode;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface SwaggerErrorDescription {
+    String name();
+    String description() default "";
+    Class<? extends Enum<? extends ErrorCode>> value();
+    String code();
+}
+
+

--- a/back/moya/src/main/java/com/study/moya/swagger/annotation/SwaggerErrorDescriptions.java
+++ b/back/moya/src/main/java/com/study/moya/swagger/annotation/SwaggerErrorDescriptions.java
@@ -1,0 +1,10 @@
+package com.study.moya.swagger.annotation;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface SwaggerErrorDescriptions {
+    SwaggerErrorDescription[] value();
+}

--- a/back/moya/src/main/java/com/study/moya/swagger/annotation/SwaggerSuccessResponse.java
+++ b/back/moya/src/main/java/com/study/moya/swagger/annotation/SwaggerSuccessResponse.java
@@ -1,0 +1,13 @@
+package com.study.moya.swagger.annotation;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface SwaggerSuccessResponse {
+    int status() default 200;
+    String name() default "";
+    Class<?> value() default Void.class;  // 응답 DTO 클래스 지정
+
+}


### PR DESCRIPTION
Swagger 커스텀 어노테이션 구현
🔍 PR 개요
Swagger API 문서화를 위한 커스텀 어노테이션과 설정을 구현했습니다. API 응답에 대한 성공/실패 케이스를 명확하게 문서화하고, JWT 인증 정보도 포함하도록 구성했습니다.
📝 변경사항
Swagger 커스텀 어노테이션 구현

@SwaggerSuccessResponse - API 성공 응답 정의
@SwaggerErrorDescription - 단일 에러 케이스 정의
@SwaggerErrorDescriptions - 복수 에러 케이스 정의

OpenAPI 설정 구현

JWT 인증 스키마 설정
API 서버 환경 설정 (운영/로컬)
응답 형식 표준화 (ApiResponse 래퍼 클래스 사용)

API 문서 커스터마이징

에러 응답에 대한 상세 설명 추가
응답 예시 자동 생성 기능 구현
API 버전 관리 체계 구축

🔗 관련 이슈

Close #124 Swagger 문서화 개선

✅ 체크리스트
로컬 테스트

 Swagger UI 정상 동작 확인
 JWT 인증 테스트 완료
 에러 응답 스키마 검증 완료

API 문서화

 성공/실패 응답 예시 추가
 에러 코드 체계 정리
 API 설명 보강

🚨 주의사항
1. 설정 관련

springdoc-openapi-ui 의존성 필요

xmlCopy<dependency>
    <groupId>org.springdoc</groupId>
    <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
    <version>2.1.0</version>
</dependency>
2. 운영 관련

Swagger UI는 운영 환경에서 비활성화 고려 필요
API 문서 버전 관리 필요

3. 에러 처리

모든 API 엔드포인트에 @SwaggerErrorDescriptions 추가 필요
ErrorCode enum 확장 시 OpenApiConfig 수정 필요

4. 확장 가이드

신규 API 작성 시 예시:

javaCopy@Operation(summary = "API 설명")
@SwaggerSuccessResponse(
    status = 200,
    name = "성공 메시지",
    value = ResponseDTO.class
)
@SwaggerErrorDescriptions({
    @SwaggerErrorDescription(
        name = "에러 설명",
        value = ErrorCode.class,
        code = "ERROR_CODE"
    )
})