### PR TITLE
KAN-136 feat. MyPage swagger 및 jwt 최신화 적용(memberId)

### DIFF
--- a/back/moya/src/main/java/com/study/moya/mypage/controller/MyPageController.java
+++ b/back/moya/src/main/java/com/study/moya/mypage/controller/MyPageController.java
@@ -1,9 +1,15 @@
 package com.study.moya.mypage.controller;
 
 import com.study.moya.global.api.ApiResponse;
+import com.study.moya.global.config.security.SecurityHeadersConfig;
 import com.study.moya.mypage.dto.MyPageResponse;
 import com.study.moya.mypage.dto.MyPageUpdateRequest;
+import com.study.moya.mypage.exception.MyPageErrorCode;
 import com.study.moya.mypage.service.MyPageService;
+import com.study.moya.swagger.annotation.SwaggerErrorDescription;
+import com.study.moya.swagger.annotation.SwaggerErrorDescriptions;
+import com.study.moya.swagger.annotation.SwaggerSuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
@@ -17,18 +23,66 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/v1/mypage")
 public class MyPageController {
     private final MyPageService myPageService;
+    private final SecurityHeadersConfig securityHeadersConfig;
 
+    @Operation(summary = "마이페이지 조회", description = "사용자의 마이페이지 정보를 조회합니다.")
+    @SwaggerSuccessResponse(
+            status = 200,
+            name = "마이페이지 조회가 완료됐습니다",
+            value = MyPageResponse.class
+    )
+    @SwaggerErrorDescriptions({
+            @SwaggerErrorDescription(
+                    name = "회원을 찾을 수 없음",
+                    value = MyPageErrorCode.class,
+                    code = "MEMBER_NOT_FOUND"
+            ),
+            @SwaggerErrorDescription(
+                    name = "차단된 회원",
+                    value = MyPageErrorCode.class,
+                    code = "MEMBER_BLOCKED"
+            ),
+            @SwaggerErrorDescription(
+                    name = "탈퇴한 회원",
+                    value = MyPageErrorCode.class,
+                    code = "MEMBER_WITHDRAWN"
+            )
+    })
     @GetMapping
-    public ResponseEntity<MyPageResponse> getMyPage(@AuthenticationPrincipal String email) {
-        MyPageResponse response = myPageService.getMyPageInfo(email);
-        return ResponseEntity.ok(response);
+    public ResponseEntity<ApiResponse<MyPageResponse>> getMyPage(@AuthenticationPrincipal Long id) {
+        MyPageResponse response = myPageService.getMyPageInfo(id);
+        return securityHeadersConfig.addSecurityHeaders(
+                ResponseEntity.ok(ApiResponse.of(response)));
     }
 
+    @Operation(summary = "마이페이지 수정", description = "사용자의 마이페이지 정보를 수정합니다.")
+    @SwaggerSuccessResponse(
+            status = 200,
+            name = "마이페이지 수정이 완료됐습니다",
+            value = MyPageResponse.class
+    )
+    @SwaggerErrorDescriptions({
+            @SwaggerErrorDescription(
+                    name = "회원을 찾을 수 없음",
+                    value = MyPageErrorCode.class,
+                    code = "MEMBER_NOT_FOUND"
+            ),
+            @SwaggerErrorDescription(
+                    name = "회원 정보 수정 불가",
+                    value = MyPageErrorCode.class,
+                    code = "MEMBER_NOT_MODIFIABLE"
+            ),
+            @SwaggerErrorDescription(
+                    name = "중복된 닉네임",
+                    value = MyPageErrorCode.class,
+                    code = "DUPLICATE_NICKNAME"
+            )
+    })
     @PutMapping
-    public ResponseEntity<MyPageResponse> updateMyPage(
-            @AuthenticationPrincipal String email,
+    public ResponseEntity<ApiResponse<MyPageResponse>> updateMyPage(
+            @AuthenticationPrincipal Long id,
             @Valid @RequestBody MyPageUpdateRequest request) {
-        MyPageResponse response = myPageService.updateMyPage(email, request);
-        return ResponseEntity.ok(response);
-    }
+        MyPageResponse response = myPageService.updateMyPage(id, request);
+        return securityHeadersConfig.addSecurityHeaders(
+                ResponseEntity.ok(ApiResponse.of(response)));    }
 }

--- a/back/moya/src/main/java/com/study/moya/mypage/dto/MyPageResponse.java
+++ b/back/moya/src/main/java/com/study/moya/mypage/dto/MyPageResponse.java
@@ -2,23 +2,28 @@ package com.study.moya.mypage.dto;
 
 import com.study.moya.member.domain.Member;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Getter
 @Schema(description = "마이페이지 응답")
-public record MyPageResponse(
-        @Schema(description = "닉네임", example = "모야")
-        String nickname,
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MyPageResponse {
+    @Schema(description = "닉네임", example = "모야")
+    private String nickname;
 
-        @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg")
-        String profileImageUrl,
+    @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg")
+    private String profileImageUrl;
 
-        @Schema(description = "자기소개", example = "안녕하세요, 백엔드 개발자입니다.")
-        String introduction
-) {
+    @Schema(description = "자기소개", example = "안녕하세요, 백엔드 개발자입니다.")
+    private String introduction;
+
     public static MyPageResponse from(Member member) {
-        return new MyPageResponse(
-                member.getNickname(),
-                member.getProfileImageUrl(),
-                member.getIntroduction()
-        );
+        MyPageResponse response = new MyPageResponse();
+        response.nickname = member.getNickname();
+        response.profileImageUrl = member.getProfileImageUrl();
+        response.introduction = member.getIntroduction();
+        return response;
     }
 }

--- a/back/moya/src/main/java/com/study/moya/mypage/dto/MyPageUpdateRequest.java
+++ b/back/moya/src/main/java/com/study/moya/mypage/dto/MyPageUpdateRequest.java
@@ -3,18 +3,23 @@ package com.study.moya.mypage.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Getter
 @Schema(description = "마이페이지 수정 요청")
-public record MyPageUpdateRequest(
-        @Schema(description = "닉네임", example = "모야")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MyPageUpdateRequest {
+        @Schema(description = "닉네임", example = "모야", required = true)
         @NotBlank(message = "닉네임은 필수입니다.")
         @Size(min = 2, max = 30, message = "닉네임은 2자 이상 30자 이하여야 합니다.")
-        String nickname,
+        private String nickname;
 
         @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg")
-        String profileImageUrl,
+        private String profileImageUrl;
 
         @Schema(description = "자기소개", example = "안녕하세요, 백엔드 개발자입니다.")
         @Size(max = 500, message = "자기소개는 500자 이하여야 합니다.")
-        String introduction
-) {}
+        private String introduction;
+}

--- a/back/moya/src/main/java/com/study/moya/mypage/service/MyPageService.java
+++ b/back/moya/src/main/java/com/study/moya/mypage/service/MyPageService.java
@@ -20,27 +20,27 @@ import org.springframework.transaction.annotation.Transactional;
 public class MyPageService {
     private final MemberRepository memberRepository;
 
-    public MyPageResponse getMyPageInfo(String email) {
-        Member member = memberRepository.findByEmail(email)
+    public MyPageResponse getMyPageInfo(Long memberId) {
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> MyPageException.of(MyPageErrorCode.MEMBER_NOT_FOUND));
         return MyPageResponse.from(member);
     }
 
     @Transactional
-    public MyPageResponse updateMyPage(String email, MyPageUpdateRequest request) {
-        Member member = memberRepository.findByEmail(email)
+    public MyPageResponse updateMyPage(Long memberId, MyPageUpdateRequest request) {
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> MyPageException.of(MyPageErrorCode.MEMBER_NOT_FOUND));
 
-        if(!member.getNickname().equals(request.nickname()) &&
+        if(!member.getNickname().equals(request.getNickname()) &&
                 memberRepository.existsByNicknameAndStatusNot(
-                        request.nickname(),
+                        request.getNickname(),
                         MemberStatus.WITHDRAWN
                 )){
             throw MyPageException.of(MyPageErrorCode.DUPLICATE_NICKNAME);
         }
-        member.updateNickname(request.nickname());
-        member.updateProfileImage(request.profileImageUrl());
-        member.updateIntroduction(request.introduction());
+        member.updateNickname(request.getNickname());
+        member.updateProfileImage(request.getProfileImageUrl());
+        member.updateIntroduction(request.getIntroduction());
 
         return MyPageResponse.from(member);
     }


### PR DESCRIPTION
MyPage Principal 적용
🔍 PR 개요
기존 MyPage 기능의 Authentication Principal을 최신 JWT 인증 방식에 맞게 수정하였습니다.
📝 변경사항
Authentication Principal 타입 변경

Controller의 Authentication Principal을 email에서 memberId로 변경
Service 메서드의 파라미터 타입 변경 및 로직 수정

MyPageService 로직 수정

회원 조회 메서드를 findByEmail에서 findById로 변경
중복 닉네임 검증 로직 유지

DTO Record 관련 수정

MyPageUpdateRequest의 getter 사용 방식으로 변경
MyPageResponse DTO 구조 유지

🔗 관련 이슈

Close #123 MyPage Authentication Principal 수정

✅ 체크리스트
로컬 테스트

 마이페이지 조회 테스트 완료
 마이페이지 수정 테스트 완료
 닉네임 중복 검증 테스트 완료

JPA 성능 최적화

 엔티티에 적절한 인덱스 추가

Member 엔티티의 nickname 인덱스 유지



캐시 정책

 캐시 적용 필요성 검토

실시간 데이터 필요로 캐시 미적용



DB 스키마 변경

 스키마 변경 없음

API 문서화

 Controller Swagger 문서 업데이트
 API 응답 예시 업데이트

🚨 주의사항
1. 설정 관련

기존 설정 유지

2. 운영 관련

기존 기능 동작에 영향 없음

3. 에러 처리

회원 조회 실패 시 MEMBER_NOT_FOUND 예외 처리
중복 닉네임 DUPLICATE_NICKNAME 예외 처리
탈퇴 회원 MEMBER_WITHDRAWN 예외 처리

4. 확장 가이드

Authentication Principal 사용 시 Long 타입의 memberId 사용