### PR TITLE
KAN-141 feat. 관리자 페이지 개발(Member, 로직만 완료)

### DIFF
--- a/back/moya/src/main/java/com/study/moya/admin/controller/AdminMemberController.java
+++ b/back/moya/src/main/java/com/study/moya/admin/controller/AdminMemberController.java
@@ -1,0 +1,34 @@
+package com.study.moya.admin.controller;
+
+import com.study.moya.admin.dto.member.AdminMemberDetailResponse;
+import com.study.moya.admin.dto.member.AdminMemberResponse;
+import com.study.moya.admin.service.AdminMemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/admin/members")
+public class AdminMemberController {
+    private final AdminMemberService adminMemberService;
+
+    @GetMapping
+    public Page<AdminMemberResponse> getMembers(Pageable pageable) {
+        return adminMemberService.getMembers(pageable);
+    }
+
+    @GetMapping("/{memberId}")
+    public AdminMemberDetailResponse getMemberDetail(@PathVariable Long memberId) {
+        return adminMemberService.getMemberDetail(memberId);
+    }
+
+    @PatchMapping("/{memberId}/block")
+    public void blockMember(@PathVariable Long memberId, @RequestBody String reason) {
+        adminMemberService.blockMember(memberId, reason);
+    }
+}
+
+
+

--- a/back/moya/src/main/java/com/study/moya/admin/dto/member/AdminMemberDetailResponse.java
+++ b/back/moya/src/main/java/com/study/moya/admin/dto/member/AdminMemberDetailResponse.java
@@ -1,0 +1,20 @@
+package com.study.moya.admin.dto.member;
+
+import com.study.moya.admin.dto.post.CommentSummary;
+import com.study.moya.admin.dto.post.LikeSummary;
+import com.study.moya.admin.dto.post.PostSummary;
+import com.study.moya.member.domain.MemberStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class AdminMemberDetailResponse {
+    private AdminMemberResponse memberInfo;
+    private List<PostSummary> posts;
+    private List<CommentSummary> comments;
+    private List<LikeSummary> likes;
+}

--- a/back/moya/src/main/java/com/study/moya/admin/dto/member/AdminMemberResponse.java
+++ b/back/moya/src/main/java/com/study/moya/admin/dto/member/AdminMemberResponse.java
@@ -1,0 +1,22 @@
+package com.study.moya.admin.dto.member;
+
+import com.study.moya.member.domain.MemberStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class AdminMemberResponse {
+    private Long id;
+    private String email;
+    private String nickname;
+    private MemberStatus status;
+    private LocalDateTime lastLoginAt;
+    private LocalDateTime createdAt;
+    private int postCount;
+    private int commentCount;
+    private int likeCount;
+}
+

--- a/back/moya/src/main/java/com/study/moya/admin/dto/post/CommentSummary.java
+++ b/back/moya/src/main/java/com/study/moya/admin/dto/post/CommentSummary.java
@@ -1,0 +1,19 @@
+package com.study.moya.admin.dto.post;
+
+import com.study.moya.posts.domain.Comment;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class CommentSummary {
+    private Long id;
+    private String content;
+    private LocalDateTime createdAt;
+
+    public CommentSummary(Comment comment) {
+        this.id = comment.getId();
+        this.content = comment.getContent();
+        this.createdAt = comment.getCreatedAt();
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/admin/dto/post/LikeSummary.java
+++ b/back/moya/src/main/java/com/study/moya/admin/dto/post/LikeSummary.java
@@ -1,0 +1,19 @@
+package com.study.moya.admin.dto.post;
+
+import com.study.moya.posts.domain.Like;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class LikeSummary {
+    private Long id;
+    private String postTitle;
+    private LocalDateTime createdAt;
+
+    public LikeSummary(Like like) {
+        this.id = like.getId();
+        this.postTitle = like.getPost().getTitle();
+        this.createdAt = like.getCreatedAt();
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/admin/dto/post/PostSummary.java
+++ b/back/moya/src/main/java/com/study/moya/admin/dto/post/PostSummary.java
@@ -1,0 +1,21 @@
+package com.study.moya.admin.dto.post;
+
+import com.study.moya.posts.domain.Post;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class PostSummary {
+    private Long id;
+    private String title;
+    private LocalDateTime createdAt;
+    private Boolean isDeleted;
+
+    public PostSummary(Post post) {
+        this.id = post.getId();
+        this.title = post.getTitle();
+        this.createdAt = post.getCreatedAt();
+        this.isDeleted = post.getIsDeleted();
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/admin/exception/AdminErrorCode.java
+++ b/back/moya/src/main/java/com/study/moya/admin/exception/AdminErrorCode.java
@@ -1,0 +1,49 @@
+package com.study.moya.admin.exception;
+
+import com.study.moya.error.constants.ErrorCode;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AdminErrorCode implements ErrorCode {
+    // 공통 에러
+    @Schema(description = "관리자 권한 없음")
+    UNAUTHORIZED_ADMIN(HttpStatus.FORBIDDEN, "001", "관리자 권한이 없습니다."),
+
+    // 회원 관리 관련 에러
+    @Schema(description = "회원을 찾을 수 없음")
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "101", "해당 회원을 찾을 수 없습니다."),
+
+    @Schema(description = "이미 차단된 회원")
+    ALREADY_BLOCKED_MEMBER(HttpStatus.BAD_REQUEST, "102", "이미 차단된 회원입니다."),
+
+    @Schema(description = "차단 사유 누락")
+    BLOCK_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "103", "차단 사유를 입력해주세요."),
+
+    // 게시물 관리 관련 에러
+    @Schema(description = "게시물을 찾을 수 없음")
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "201", "해당 게시물을 찾을 수 없습니다."),
+
+    @Schema(description = "이미 삭제된 게시물")
+    ALREADY_DELETED_POST(HttpStatus.BAD_REQUEST, "202", "이미 삭제된 게시물입니다."),
+
+    // 쿠폰 관리 관련 에러
+    @Schema(description = "통계 기간 오류")
+    INVALID_STATISTICS_PERIOD(HttpStatus.BAD_REQUEST, "301", "유효하지 않은 통계 조회 기간입니다."),
+
+    @Schema(description = "쿠폰 통계 조회 실패")
+    STATISTICS_RETRIEVAL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "302", "쿠폰 통계 조회 중 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+    private static final String PREFIX = "ADMIN";
+
+    @Override
+    public String getFullCode() {
+        return PREFIX + "_" + code;
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/admin/exception/AdminException.java
+++ b/back/moya/src/main/java/com/study/moya/admin/exception/AdminException.java
@@ -1,0 +1,22 @@
+package com.study.moya.admin.exception;
+
+import com.study.moya.error.exception.BaseException;
+
+public class AdminException extends BaseException {
+    protected AdminException(AdminErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public static AdminException of(AdminErrorCode errorCode) {
+        return new AdminException(errorCode);
+    }
+
+    public static AdminException of(AdminErrorCode errorCode, String customMessage) {
+        return new AdminException(errorCode) {
+            @Override
+            public String getMessage() {
+                return customMessage;
+            }
+        };
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/admin/service/AdminMemberService.java
+++ b/back/moya/src/main/java/com/study/moya/admin/service/AdminMemberService.java
@@ -1,0 +1,98 @@
+package com.study.moya.admin.service;
+
+import com.study.moya.admin.dto.member.AdminMemberDetailResponse;
+import com.study.moya.admin.dto.member.AdminMemberResponse;
+import com.study.moya.admin.dto.post.CommentSummary;
+import com.study.moya.admin.dto.post.LikeSummary;
+import com.study.moya.admin.dto.post.PostSummary;
+import com.study.moya.admin.exception.AdminErrorCode;
+import com.study.moya.admin.exception.AdminException;
+import com.study.moya.error.constants.MemberErrorCode;
+import com.study.moya.error.exception.MemberException;
+import com.study.moya.member.domain.Member;
+import com.study.moya.member.domain.MemberStatus;
+import com.study.moya.member.repository.MemberRepository;
+import com.study.moya.posts.domain.Comment;
+import com.study.moya.posts.domain.Like;
+import com.study.moya.posts.domain.Post;
+import com.study.moya.posts.repository.CommentRepository;
+import com.study.moya.posts.repository.LikeRepository;
+import com.study.moya.posts.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import org.springframework.data.domain.Pageable;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AdminMemberService {
+    private final MemberRepository memberRepository;
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+    private final LikeRepository likeRepository;
+
+    public Page<AdminMemberResponse> getMembers(Pageable pageable) {
+        // ID가 4 이상인 회원만 조회하도록 수정
+        Page<Member> membersPage = memberRepository.findByIdGreaterThanEqual(3701L, pageable);
+        return membersPage.map(this::convertToAdminMemberResponseDto);
+    }
+
+    public AdminMemberDetailResponse getMemberDetail(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> AdminException.of(AdminErrorCode.MEMBER_NOT_FOUND));
+        return convertToAdminMemberDetailResponseDto(member);
+    }
+
+    @Transactional
+    public void blockMember(Long memberId, String reason) {
+        if (reason == null || reason.trim().isEmpty()) {
+            throw AdminException.of(AdminErrorCode.BLOCK_REASON_REQUIRED);
+        }
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> AdminException.of(AdminErrorCode.MEMBER_NOT_FOUND));
+
+        if (member.getStatus() == MemberStatus.BLOCKED) {
+            throw AdminException.of(AdminErrorCode.ALREADY_BLOCKED_MEMBER);
+        }
+
+        member.block(reason);
+    }
+
+    private AdminMemberResponse convertToAdminMemberResponseDto(Member member) {
+        return AdminMemberResponse.builder()
+                .id(member.getId())
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .status(member.getStatus())
+                .lastLoginAt(member.getLastLoginAt())
+                .createdAt(member.getCreatedAt())
+                .postCount(postRepository.countByAuthor(member))
+                .commentCount(commentRepository.countByAuthor(member))
+                .likeCount(likeRepository.countByMember(member))
+                .build();
+    }
+
+    private AdminMemberDetailResponse convertToAdminMemberDetailResponseDto(Member member) {
+        AdminMemberResponse memberResponse = convertToAdminMemberResponseDto(member);
+
+        return AdminMemberDetailResponse.builder()
+                .memberInfo(memberResponse)
+                .posts(postRepository.findByAuthor(member).stream()
+                        .map(PostSummary::new)
+                        .collect(Collectors.toList()))
+                .comments(commentRepository.findByAuthor(member).stream()
+                        .map(CommentSummary::new)
+                        .collect(Collectors.toList()))
+                .likes(likeRepository.findByMember(member).stream()
+                        .map(LikeSummary::new)
+                        .collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/member/repository/MemberRepository.java
+++ b/back/moya/src/main/java/com/study/moya/member/repository/MemberRepository.java
@@ -4,7 +4,10 @@ import com.study.moya.member.domain.Member;
 import java.util.Optional;
 
 import com.study.moya.member.domain.MemberStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -17,4 +20,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByNickname(String nickname);
 
     boolean existsByNicknameAndStatusNot(String nickname, MemberStatus status);
+
+    Page<Member> findByIdGreaterThanEqual(Long startId, Pageable pageable);
 }

--- a/back/moya/src/main/java/com/study/moya/posts/repository/CommentRepository.java
+++ b/back/moya/src/main/java/com/study/moya/posts/repository/CommentRepository.java
@@ -1,9 +1,17 @@
 package com.study.moya.posts.repository;
 
+import com.study.moya.member.domain.Member;
 import com.study.moya.posts.domain.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.List;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    int countByAuthor(Member member);
+
+    List<Comment> findByAuthor(@Param("author") Member author);
 }

--- a/back/moya/src/main/java/com/study/moya/posts/repository/LikeRepository.java
+++ b/back/moya/src/main/java/com/study/moya/posts/repository/LikeRepository.java
@@ -1,9 +1,13 @@
 package com.study.moya.posts.repository;
 
+import com.study.moya.member.domain.Member;
 import com.study.moya.posts.domain.Like;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -11,4 +15,8 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
     Optional<Like> findByMemberIdAndPostId(Long memberId, Long postId);
 
     int countByPostId(Long postId);
+
+    int countByMember(Member member);
+
+    List<Like> findByMember(@Param("member") Member member);
 }

--- a/back/moya/src/main/java/com/study/moya/posts/repository/PostRepository.java
+++ b/back/moya/src/main/java/com/study/moya/posts/repository/PostRepository.java
@@ -1,12 +1,21 @@
 package com.study.moya.posts.repository;
 
+import com.study.moya.member.domain.Member;
 import com.study.moya.posts.domain.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.List;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findByIsDeletedFalse(Pageable pageable);
+
+    int countByAuthor(Member member);
+
+    List<Post> findByAuthor(@Param("author") Member author);
 }


### PR DESCRIPTION
관리자 회원 관리 기능 구현
🔍 PR 개요
관리자 페이지에서 회원 정보를 조회하고 관리할 수 있는 기능을 구현했습니다. 회원 목록 조회, 상세 정보 확인, 그리고 악성 사용자 차단 기능을 포함합니다.
📝 변경사항
관리자 회원 목록 조회 기능 구현

페이징 처리된 회원 목록 API 구현
회원의 기본 정보(이메일, 닉네임, 상태 등) 및 활동 통계(게시글, 댓글, 좋아요 수) 제공
ID가 3701 이상인 회원만 조회하도록 필터링 적용

회원 상세 정보 조회 기능 구현

특정 회원의 상세 정보 조회 API 구현
회원이 작성한 게시글, 댓글, 좋아요 목록 포함
각 항목별 요약 정보(ID, 제목, 생성일 등) 제공

회원 차단 기능 구현

악성 사용자를 차단할 수 있는 API 구현
차단 사유 필수 입력 검증 로직 추가
이미 차단된 회원에 대한 예외 처리

🔗 관련 이슈

Close #123 관리자 회원 관리 기능 구현

✅ 체크리스트
로컬 테스트

 회원 목록 조회 테스트 완료
 회원 상세 정보 조회 테스트 완료
 회원 차단 기능 테스트 완료

JPA 성능 최적화

 엔티티에 적절한 인덱스 추가

Member 엔티티의 email, nickname 필드에 인덱스 추가


 N+1 문제 해결

상세 정보 조회 시 회원 관련 게시글, 댓글, 좋아요를 개별 쿼리로 조회하는 방식 사용
향후 @EntityGraph 또는 fetch join으로 개선 예정



캐시 정책

 캐시 적용 필요성 검토

현재는 실시간 데이터 조회가 중요하므로 캐시 미적용
접속자가 증가할 경우 회원 목록 조회에 캐시 적용 고려



DB 스키마 변경

 테이블 수정

sqlCopy-- Member 테이블에 block_reason 컬럼 추가
ALTER TABLE member ADD COLUMN block_reason VARCHAR(255);
API 문서화

 Controller에 @Tag 추가
 API 설명 추가

🚨 주의사항
1. 설정 관련

관리자 권한 체크는 현재 Spring Security 설정에 의존하므로 SecurityConfig 설정 확인 필요

2. 운영 관련

회원 차단 시 해당 회원의 모든 세션이 즉시 만료되므로 대량 차단 작업은 서비스 부하가 적은 시간에 수행 권장

3. 에러 처리

관리자 권한 관련 예외는 FORBIDDEN(403) 상태코드로 반환
회원 조회 실패는 NOT_FOUND(404) 상태코드로 반환
차단 관련 유효성 검증 실패는 BAD_REQUEST(400) 상태코드로 반환

4. 확장 가이드

회원 필터링 기능 추가 시 MemberRepository에 메소드 추가
상세 정보에 추가 데이터 필요 시 AdminMemberDetailResponse DTO 확장