### PR TITLE
Kan 167 학습지 문제 정의 및 에러 해결

### DIFF
--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/controller/RoadmapController.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/controller/RoadmapController.java
@@ -12,6 +12,7 @@ import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -33,10 +34,10 @@ public class RoadmapController {
 
     @PostMapping("/generate")
     public CompletableFuture<ResponseEntity<WeeklyRoadmapResponse>> generateWeeklyRoadmap(
-            @Valid @RequestBody RoadmapRequest request
+            @Valid @RequestBody RoadmapRequest request, @AuthenticationPrincipal Long memberId
     ) {
         log.info("작동해버리기~============================");
-        return roadMapService.generateWeeklyRoadmapAsync(request)
+        return roadMapService.generateWeeklyRoadmapAsync(request, memberId)
                 .thenApply(response -> ResponseEntity.ok(response))
                 .exceptionally(ex -> {
                     // 예외 발생 시 처리
@@ -48,9 +49,7 @@ public class RoadmapController {
     public ResponseEntity<Void> generateWorksheets(@PathVariable Long roadmapId) {
         log.info("로드맵 ID: {}의 학습지 생성 시작", roadmapId);
         worksheetService.generateAllWorksheets(roadmapId)
-                .thenRun(() -> {
-                    log.info("로드맵 ID: {}의 학습지 생성 완료", roadmapId);
-                })
+                .thenRun(() -> log.info("로드맵 ID: {}의 학습지 생성 완료", roadmapId))
                 .exceptionally(ex -> {
                     log.error("학습지 생성 중 오류 발생: {}", ex.getMessage());
                     return null;

--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/service/RoadmapService.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/service/RoadmapService.java
@@ -55,7 +55,7 @@ public class RoadmapService {
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
     @Async
-    public CompletableFuture<WeeklyRoadmapResponse> generateWeeklyRoadmapAsync(RoadmapRequest request) {
+    public CompletableFuture<WeeklyRoadmapResponse> generateWeeklyRoadmapAsync(RoadmapRequest request, Long memberId) {
         return CompletableFuture.supplyAsync(() -> {
             log.info("로드맵 생성 시작");
 
@@ -98,7 +98,6 @@ public class RoadmapService {
         });
     }
 
-    @Transactional
     public Long saveCurriculum(int goalLevel, String topic, int duration, LearningObjective learningObjective,
                                WeeklyRoadmapResponse response) {
         log.info("커리큘럼 저장 시작");

--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/service/WorksheetPromptService.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/service/WorksheetPromptService.java
@@ -12,18 +12,11 @@ import org.springframework.stereotype.Service;
 public class WorksheetPromptService {
 
     private static final String SYSTEM_PROMPT = """
-        당신은 프로그래밍 교육 전문가입니다. 주어진 3일간의 학습 키워드에 대해 상세한 학습 가이드를 작성해주세요.
+        당신은 프로그래밍 교육 전문가입니다. 주어진 일차의 학습 키워드에 대해 상세한 학습 가이드를 작성해주세요.
         
         응답은 반드시 아래 형식을 따라주세요. 절대로 마크다운이나 특수문자, 번호 매기기를 사용하지 마세요.
         
-        === DAY {일차} ===
-        [여기에 학습 가이드 내용을 자연스러운 문장으로 작성]
-        
-        === DAY {일차} ===
-        [여기에 학습 가이드 내용을 자연스러운 문장으로 작성]
-        
-        === DAY {일차} ===
-        [여기에 학습 가이드 내용을 자연스러운 문장으로 작성]
+        %s
         
         각 일자별 학습 가이드는 다음 내용을 자연스러운 문장으로 포함해야 합니다:
         - 해당 주제의 중요성
@@ -40,13 +33,21 @@ public class WorksheetPromptService {
         """;
 
     public String createPrompt(List<DailyPlan> dailyPlans) {
+
+        StringBuilder dayFormatBuilder = new StringBuilder();
+        for (DailyPlan plan : dailyPlans) {
+            dayFormatBuilder.append(String.format("=== DAY %d ===\n[여기에 학습 가이드 내용을 자연스러운 문장으로 작성]\n\n", plan.getDayNumber()));
+        }
+        String dayFormat = dayFormatBuilder.toString().trim();
+
+        String systemPrompt = String.format(SYSTEM_PROMPT, dayFormat);
+
         StringBuilder promptBuilder = new StringBuilder();
-        promptBuilder.append(SYSTEM_PROMPT).append("\n\n");
+        promptBuilder.append(systemPrompt).append("\n\n");
         promptBuilder.append("다음 키워드들에 대한 학습 가이드를 작성해주세요:\n");
 
         for (DailyPlan plan : dailyPlans) {
-            promptBuilder.append(String.format("Day %d: %s\n",
-                    plan.getDayNumber(), plan.getKeyword()));
+            promptBuilder.append(String.format("Day %d: %s\n", plan.getDayNumber(), plan.getKeyword()));
         }
 
         return promptBuilder.toString();


### PR DESCRIPTION
## 🔍 PR 개요

이 PR은 AI 로드맵 애플리케이션에 학습지 생성 기능을 구현합니다. `WorksheetPromptService`와 `WorksheetService` 클래스를 도입하여 데일리 플랜에 대한 학습 가이드를 생성하고 데이터베이스에 저장하며, 진행 상황을 추적하는 기능을 제공합니다. 또한, 학습지 생성 중 발생하던 에러를 해결하고 트랜잭션 관리를 추가하여 안정성과 데이터 일관성을 확보했습니다.

## 📝 변경사항

### 주요 기능 1 구현

- **Worksheet Prompt Creation**
    - `WorksheetPromptService`를 수정하여 OpenAI API에 전달할 구조화된 프롬프트를 생성했습니다.
    - `SYSTEM_PROMPT` 템플릿을 정의하여 학습 가이드에 중요성, 핵심 내용, 활용 방법, 예제, 주의사항 섹션을 포함하도록 AI를 안내합니다.
    - 데일리 플랜을 `=== DAY {day_number} ===` 형식으로 포맷팅하여 일자별 키워드 기반 프롬프트를 생성했습니다.

### 주요 기능 2 구현

- **Worksheet Generation and Storage**
    - `WorksheetService`를 구현하여 OpenAI API를 활용한 학습지 생성 프로세스를 관리합니다.
    - `@Async`를 사용한 비동기 처리로 데일리 플랜을 3일 단위로 그룹화하여 생성 속도를 개선했습니다.
    - API 호출 실패 시 최대 3회 재시도와 지수 백오프를 적용하여 안정성을 높였습니다.
    - 생성된 학습지 내용을 `DailyPlan` 엔티티의 `work_sheet` 컬럼에 저장하고 데이터베이스에 반영했습니다.
    - 트랜잭션 관리를 위해 `@Transactional`을 추가하여 데이터 일관성을 보장했습니다.

## ✅ 체크리스트

### 로컬 테스트

- [x]  학습지 프롬프트 생성 테스트 완료
- [x]  학습지 생성 및 저장 테스트 완료
- [x]  학습지 생성 시, 사용자 정보 전달 완료

### JPA 성능 최적화

- [x]  엔티티에 적절한 인덱스 추가
    - `daily_plans` 테이블의 `weekly_plan_id` 컬럼에 인덱스를 추가하여 `findAllByWeeklyPlan_RoadMap_IdOrderByDayNumber` 쿼리 성능을 최적화했습니다.
- [x]  N+1 문제 해결
    - `findAllByWeeklyPlan_RoadMap_IdOrderByDayNumber` 쿼리에 `fetch join`을 적용하여 `DailyPlan`과 `WeeklyPlan`을 단일 쿼리로 조회하며 N+1 문제를 해결했습니다.

### 캐시 정책

- [x]  캐시 적용 필요성 검토
    - 검토 결과: 학습지 생성은 로드맵당 한 번만 실행되므로 캐시가 필요하지 않다고 판단했습니다.
    - 적용 방안: `getWorksheetProgress` 메서드에 대해 빈번한 호출이 관찰될 경우 캐시 적용을 고려할 수 있습니다.

## 🚨 주의사항

### 1. 설정 관련

- `application.properties`에서 `openai.api.models.worksheet_generation.model` 속성을 설정하여 학습지 생성에 사용할 OpenAI 모델을 지정해야 합니다.

### 2. 운영 관련

- OpenAI API 호출이 배치 단위로 이루어지므로 API 토큰 사용량과 속도 제한을 모니터링하세요. 제한 오류 발생 시 `DELAY_MS` 상수를 조정할 수 있습니다.

### 3. 에러 처리!!

- OpenAI API 호출 실패 시 최대 3회 재시도 후 `RuntimeException`을 발생시킵니다. 에러 발생 시 로그를 확인하고, 필요하면 재시도 횟수(`MAX_RETRIES`)를 조정하거나 API 상태를 점검하세요.

### 4. 확장 가이드

- 프롬프트 형식을 확장하려면 `WorksheetPromptService`의 `SYSTEM_PROMPT`를 수정하되, 마크다운 및 불릿 포인트 사용 금지 규칙을 준수하세요.
- OpenAI 응답 형식이 변경될 경우 `WorksheetResponseParser` 클래스를 확장하여 새로운 파싱 로직을 추가할 수 있습니다.
- 그룹 크기를 조정하려면 `splitIntoGroups` 메서드의 `groupSize` 값을 변경하여 API 호출 빈도를 최적화하세요.