### PR TITLE
KAN-145 feat. 토큰 테이블 설계 및 API 설계

### DIFF
--- a/back/moya/src/main/java/com/study/moya/admin/controller/AdminPostController.java
+++ b/back/moya/src/main/java/com/study/moya/admin/controller/AdminPostController.java
@@ -1,0 +1,26 @@
+//package com.study.moya.admin.controller;
+//
+//import org.springframework.web.bind.annotation.*;
+//
+//import java.awt.print.Pageable;
+//
+//@RestController
+//@RequestMapping("/api/admin/posts")
+//public class AdminPostController {
+//    private final AdminPostService adminPostService;
+//
+//    @GetMapping
+//    public Page<AdminPostResponse> getPosts(Pageable pageable) {
+//        return adminPostService.getPosts(pageable);
+//    }
+//
+//    @GetMapping("/{postId}")
+//    public AdminPostDetailResponse getPostDetail(@PathVariable Long postId) {
+//        return adminPostService.getPostDetail(postId);
+//    }
+//
+//    @DeleteMapping("/{postId}")
+//    public void deletePost(@PathVariable Long postId) {
+//        adminPostService.deletePost(postId);
+//    }
+//}

--- a/back/moya/src/main/java/com/study/moya/token/controller/TokenApiController.java
+++ b/back/moya/src/main/java/com/study/moya/token/controller/TokenApiController.java
@@ -1,0 +1,123 @@
+package com.study.moya.token.controller;
+
+import com.study.moya.token.dto.account.TokenBalanceResponse;
+import com.study.moya.token.dto.charge.ChargeTokenRequest;
+import com.study.moya.token.dto.charge.PaymentConfirmRequest;
+import com.study.moya.token.dto.charge.PaymentResponse;
+import com.study.moya.token.dto.charge.TokenPackageResponse;
+import com.study.moya.token.dto.transaction.TokenTransactionDto;
+import com.study.moya.token.dto.usage.AiServiceResponse;
+import com.study.moya.token.dto.usage.AiUsageDto;
+import com.study.moya.token.dto.usage.AiUsageResponse;
+import com.study.moya.token.dto.usage.UseTokenRequest;
+import com.study.moya.token.service.TokenFacadeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/tokens")
+@RequiredArgsConstructor
+public class TokenApiController {
+
+    private final TokenFacadeService tokenFacadeService;
+
+    @GetMapping("/balance")
+    public ResponseEntity<TokenBalanceResponse> getTokenBalance(
+            @AuthenticationPrincipal Long memberId) {
+
+        return ResponseEntity.ok(tokenFacadeService.getTokenBalance(memberId));
+    }
+
+    @GetMapping("/packages")
+    public ResponseEntity<TokenPackageResponse> getAvailableTokenPackages() {
+        return ResponseEntity.ok(tokenFacadeService.getAvailableTokenPackages());
+    }
+
+    @PostMapping("/charge")
+    public ResponseEntity<PaymentResponse> requestTokenCharge(
+            @AuthenticationPrincipal Long memberId,
+            @RequestBody ChargeTokenRequest request) {
+
+        return ResponseEntity.ok(tokenFacadeService.requestTokenCharge(memberId, request));
+    }
+
+    @PostMapping("/payments/confirm")
+    public ResponseEntity<PaymentResponse> confirmPayment(
+            @RequestBody PaymentConfirmRequest request) {
+
+        return ResponseEntity.ok(tokenFacadeService.confirmPayment(request));
+    }
+
+    @GetMapping("/ai-services")
+    public ResponseEntity<AiServiceResponse> getAvailableAiServices() {
+        return ResponseEntity.ok(tokenFacadeService.getAvailableAiServices());
+    }
+
+    @GetMapping("/ai-services/type/{serviceType}")
+    public ResponseEntity<AiServiceResponse> getAvailableAiServicesByType(
+            @PathVariable String serviceType) {
+
+        return ResponseEntity.ok(tokenFacadeService.getAvailableAiServicesByType(serviceType));
+    }
+
+    @PostMapping("/use")
+    public ResponseEntity<AiUsageResponse> useTokenForAiService(
+            @AuthenticationPrincipal Long memberId,
+            @RequestBody UseTokenRequest request) {;
+
+        return ResponseEntity.ok(tokenFacadeService.useTokenForAiService(memberId, request));
+    }
+
+    @GetMapping("/transactions")
+    public ResponseEntity<Page<TokenTransactionDto>> getMemberTransactions(
+            @AuthenticationPrincipal Long memberId,
+            Pageable pageable) {
+
+        return ResponseEntity.ok(tokenFacadeService.getMemberTransactions(memberId, pageable));
+    }
+
+    @GetMapping("/transactions/period")
+    public ResponseEntity<List<TokenTransactionDto>> getMemberTransactionsBetween(
+            @AuthenticationPrincipal Long memberId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end) {
+
+        return ResponseEntity.ok(tokenFacadeService.getMemberTransactionsBetween(memberId, start, end));
+    }
+
+    @GetMapping("/ai-usages")
+    public ResponseEntity<Page<AiUsageDto>> getMemberAiUsages(
+            @AuthenticationPrincipal Long memberId,
+            Pageable pageable) {
+
+
+        return ResponseEntity.ok(tokenFacadeService.getMemberAiUsages(memberId, pageable));
+    }
+
+    @GetMapping("/ai-usages/period")
+    public ResponseEntity<List<AiUsageDto>> getMemberAiUsagesBetween(
+            @AuthenticationPrincipal Long memberId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end) {
+
+
+        return ResponseEntity.ok(tokenFacadeService.getMemberAiUsagesBetween(memberId, start, end));
+    }
+
+    // 관리자 전용 API
+    @PostMapping("/admin/process-ai-usages")
+    public ResponseEntity<Void> processAiUsageResults() {
+        tokenFacadeService.processAiUsageResults();
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/back/moya/src/main/java/com/study/moya/token/domain/AiService.java
+++ b/back/moya/src/main/java/com/study/moya/token/domain/AiService.java
@@ -1,0 +1,27 @@
+package com.study.moya.token.domain;
+
+import com.study.moya.BaseEntity;
+import com.study.moya.token.domain.enums.AiServiceType;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Table(name = "ai_services")
+@Getter
+public class AiService extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String serviceName;
+
+    @Enumerated(EnumType.STRING)
+    private AiServiceType serviceType;
+
+    private Long tokenCost;
+
+    private Boolean isActive;
+
+    // 생성자, 메서드 등
+}

--- a/back/moya/src/main/java/com/study/moya/token/domain/AiUsage.java
+++ b/back/moya/src/main/java/com/study/moya/token/domain/AiUsage.java
@@ -1,0 +1,53 @@
+package com.study.moya.token.domain;
+
+import com.study.moya.BaseEntity;
+import com.study.moya.member.domain.Member;
+import com.study.moya.token.domain.enums.AiUsageStatus;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "ai_usages")
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class AiUsage extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "service_id", nullable = false)
+    private AiService aiService;
+
+    @Column(columnDefinition = "TEXT")
+    private String requestData;
+
+    private Long tokenCost;
+
+    private Long actualTokenUsage;
+
+    @Enumerated(EnumType.STRING)
+    private AiUsageStatus status;
+
+    public void completeUsage() {
+        this.status = AiUsageStatus.COMPLETED;
+    }
+
+    public void failUsage() {
+        this.status = AiUsageStatus.FAILED;
+    }
+
+    public void recordActualTokenUsage(Long actualTokenUsage) {
+        this.actualTokenUsage = actualTokenUsage;
+    }
+
+}

--- a/back/moya/src/main/java/com/study/moya/token/domain/Payment.java
+++ b/back/moya/src/main/java/com/study/moya/token/domain/Payment.java
@@ -1,0 +1,59 @@
+package com.study.moya.token.domain;
+
+import com.study.moya.BaseEntity;
+import com.study.moya.member.domain.Member;
+import com.study.moya.token.domain.enums.PaymentMethod;
+import com.study.moya.token.domain.enums.PaymentStatus;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "payments")
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class Payment extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(unique = true)
+    private String orderId;
+
+    private Long amount;
+
+    @Column(length = 3)
+    private String currency;
+
+    @Enumerated(EnumType.STRING)
+    private PaymentMethod paymentMethod;
+
+    private String paymentGateway;
+
+    @Enumerated(EnumType.STRING)
+    private PaymentStatus paymentStatus;
+
+    private Long tokenAmount;
+
+    private LocalDateTime paymentApprovedAt;
+
+    // Builder 패턴이 사용되면 setter 대신 이 메서드 사용
+    public void completePayment() {
+        this.paymentStatus = PaymentStatus.COMPLETED;
+        this.paymentApprovedAt = LocalDateTime.now();
+    }
+
+    public void updatePaymentStatus(PaymentStatus status) {
+        this.paymentStatus = status;
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/token/domain/TokenAccount.java
+++ b/back/moya/src/main/java/com/study/moya/token/domain/TokenAccount.java
@@ -1,0 +1,52 @@
+package com.study.moya.token.domain;
+
+import com.study.moya.BaseEntity;
+import com.study.moya.member.domain.Member;
+import com.study.moya.token.exception.TokenErrorCode;
+import com.study.moya.token.exception.TokenException;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AccessLevel;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "token_accounts")
+public class TokenAccount extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "member_id", nullable = false, unique = true)
+    private Member member;
+
+    @Column(nullable = false)
+    private Long balance;
+
+    @Version
+    private Long version;  // 낙관적 락을 통한 동시성 제어
+
+    @Builder
+    public TokenAccount(Member member, Long balance) {
+        this.member = member;
+        this.balance = balance;
+    }
+
+    // 생성자, 메서드 등
+    public void addTokens(Long amount) {
+        this.balance += amount;
+    }
+
+    // 예외 처리 없이 값만 변경
+    public void useTokens(Long amount) {
+        this.balance -= amount;
+    }
+
+    // 토큰 잔액 조회 메서드 추가
+    public boolean hasEnoughTokens(Long amount) {
+        return this.balance >= amount;
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/token/domain/TokenPackage.java
+++ b/back/moya/src/main/java/com/study/moya/token/domain/TokenPackage.java
@@ -1,0 +1,27 @@
+package com.study.moya.token.domain;
+
+import com.study.moya.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Table(name = "token_packages")
+@Getter
+public class TokenPackage extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String packageName;
+
+    private Long tokenAmount;
+
+    private Long price;
+
+    @Column(length = 3)
+    private String currency;
+
+    private Boolean isActive;
+
+    // 생성자, 메서드 등
+}

--- a/back/moya/src/main/java/com/study/moya/token/domain/TokenTransaction.java
+++ b/back/moya/src/main/java/com/study/moya/token/domain/TokenTransaction.java
@@ -1,0 +1,48 @@
+package com.study.moya.token.domain;
+
+import com.study.moya.BaseEntity;
+import com.study.moya.token.domain.enums.PaymentMethod;
+import com.study.moya.token.domain.enums.TransactionType;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "token_transactions")
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenTransaction extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "token_account_id", nullable = false)
+    private TokenAccount tokenAccount;
+
+    @ManyToOne
+    @JoinColumn(name = "payment_id")
+    private Payment payment;
+
+    @ManyToOne
+    @JoinColumn(name = "ai_usage_id")
+    private AiUsage aiUsage;
+
+    private Long amount;
+
+    @Enumerated(EnumType.STRING)
+    private TransactionType transactionType;
+
+    @Enumerated(EnumType.STRING)
+    private PaymentMethod paymentMethod;
+
+    private Long balanceAfter;
+
+    private String description;
+
+    private String createdBy;
+}

--- a/back/moya/src/main/java/com/study/moya/token/domain/constants/TokenConstants.java
+++ b/back/moya/src/main/java/com/study/moya/token/domain/constants/TokenConstants.java
@@ -1,0 +1,30 @@
+package com.study.moya.token.domain.constants;
+
+public final class TokenConstants {
+    private TokenConstants() {
+        // 인스턴스화 방지
+    }
+
+    // 토큰 계정 관련 상수
+    public static final Long INITIAL_TOKEN_BALANCE = 0L;
+
+    // 거래 타입
+    public static final String TRANSACTION_TYPE_CHARGE = "CHARGE";
+    public static final String TRANSACTION_TYPE_USAGE = "USAGE";
+
+    // 결제 상태
+    public static final String PAYMENT_STATUS_PENDING = "PENDING";
+    public static final String PAYMENT_STATUS_COMPLETED = "COMPLETED";
+    public static final String PAYMENT_STATUS_FAILED = "FAILED";
+    public static final String PAYMENT_STATUS_REFUNDED = "REFUNDED";
+
+    // 결제 방법
+    public static final String PAYMENT_METHOD_CARD = "CREDIT_CARD";
+    public static final String PAYMENT_METHOD_BANK = "BANK_TRANSFER";
+    public static final String PAYMENT_METHOD_VIRTUAL = "VIRTUAL_ACCOUNT";
+
+    // AI 서비스 상태
+    public static final String AI_USAGE_STATUS_PENDING = "PENDING";
+    public static final String AI_USAGE_STATUS_COMPLETED = "COMPLETED";
+    public static final String AI_USAGE_STATUS_FAILED = "FAILED";
+}

--- a/back/moya/src/main/java/com/study/moya/token/domain/enums/AiServiceType.java
+++ b/back/moya/src/main/java/com/study/moya/token/domain/enums/AiServiceType.java
@@ -1,0 +1,6 @@
+package com.study.moya.token.domain.enums;
+
+public enum AiServiceType {
+    ROADMAP,
+    WORKSHEET
+}

--- a/back/moya/src/main/java/com/study/moya/token/domain/enums/AiUsageStatus.java
+++ b/back/moya/src/main/java/com/study/moya/token/domain/enums/AiUsageStatus.java
@@ -1,0 +1,7 @@
+package com.study.moya.token.domain.enums;
+
+public enum AiUsageStatus {
+    PENDING,    // 대기 중
+    COMPLETED,  // 완료됨
+    FAILED      // 실패함
+}

--- a/back/moya/src/main/java/com/study/moya/token/domain/enums/PaymentMethod.java
+++ b/back/moya/src/main/java/com/study/moya/token/domain/enums/PaymentMethod.java
@@ -1,0 +1,7 @@
+package com.study.moya.token.domain.enums;
+
+public enum PaymentMethod {
+    CREDIT_CARD,    // 신용카드
+    BANK_TRANSFER,  // 계좌이체
+    VIRTUAL_ACCOUNT // 가상계좌
+}

--- a/back/moya/src/main/java/com/study/moya/token/domain/enums/PaymentStatus.java
+++ b/back/moya/src/main/java/com/study/moya/token/domain/enums/PaymentStatus.java
@@ -1,0 +1,8 @@
+package com.study.moya.token.domain.enums;
+
+public enum PaymentStatus {
+    PENDING,    // 결제 대기 중
+    COMPLETED,  // 결제 완료
+    FAILED,     // 결제 실패
+    REFUNDED    // 환불됨
+}

--- a/back/moya/src/main/java/com/study/moya/token/domain/enums/TransactionType.java
+++ b/back/moya/src/main/java/com/study/moya/token/domain/enums/TransactionType.java
@@ -1,0 +1,9 @@
+package com.study.moya.token.domain.enums;
+
+public enum TransactionType {
+    CHARGE,         // 충전
+    USAGE,          // 사용
+    REFUND,         // 환불
+    ADMIN_CHARGE,   // 관리자 추가
+    ADMIN_DEDUCT    // 관리자 차감
+}

--- a/back/moya/src/main/java/com/study/moya/token/dto/account/TokenAccountDto.java
+++ b/back/moya/src/main/java/com/study/moya/token/dto/account/TokenAccountDto.java
@@ -1,0 +1,31 @@
+package com.study.moya.token.dto.account;
+
+import com.study.moya.token.domain.TokenAccount;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenAccountDto {
+    private Long id;
+    private Long memberId;
+    private Long balance;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static TokenAccountDto from(TokenAccount tokenAccount) {
+        return TokenAccountDto.builder()
+                .id(tokenAccount.getId())
+                .memberId(tokenAccount.getMember().getId())
+                .balance(tokenAccount.getBalance())
+                .createdAt(tokenAccount.getCreatedAt())
+                .updatedAt(tokenAccount.getModifiedAt())
+                .build();
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/token/dto/account/TokenBalanceResponse.java
+++ b/back/moya/src/main/java/com/study/moya/token/dto/account/TokenBalanceResponse.java
@@ -1,0 +1,18 @@
+package com.study.moya.token.dto.account;
+
+import com.study.moya.token.dto.transaction.TokenTransactionDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenBalanceResponse {
+    private Long balance;
+    private List<TokenTransactionDto> recentTransactions;
+}

--- a/back/moya/src/main/java/com/study/moya/token/dto/charge/ChargeTokenRequest.java
+++ b/back/moya/src/main/java/com/study/moya/token/dto/charge/ChargeTokenRequest.java
@@ -1,0 +1,15 @@
+package com.study.moya.token.dto.charge;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChargeTokenRequest {
+    private Long tokenPackageId;
+    private String paymentMethod;
+}

--- a/back/moya/src/main/java/com/study/moya/token/dto/charge/PaymentConfirmRequest.java
+++ b/back/moya/src/main/java/com/study/moya/token/dto/charge/PaymentConfirmRequest.java
@@ -1,0 +1,15 @@
+package com.study.moya.token.dto.charge;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentConfirmRequest {
+    private String orderId;
+    private String paymentStatus;
+}

--- a/back/moya/src/main/java/com/study/moya/token/dto/charge/PaymentDto.java
+++ b/back/moya/src/main/java/com/study/moya/token/dto/charge/PaymentDto.java
@@ -1,0 +1,43 @@
+package com.study.moya.token.dto.charge;
+
+import com.study.moya.token.domain.Payment;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentDto {
+    private Long id;
+    private Long memberId;
+    private String orderId;
+    private Long amount;
+    private String currency;
+    private String paymentMethod;
+    private String paymentGateway;
+    private String paymentStatus;
+    private Long tokenAmount;
+    private LocalDateTime paymentApprovedAt;
+    private LocalDateTime createdAt;
+
+    public static PaymentDto from(Payment payment) {
+        return PaymentDto.builder()
+                .id(payment.getId())
+                .memberId(payment.getMember().getId())
+                .orderId(payment.getOrderId())
+                .amount(payment.getAmount())
+                .currency(payment.getCurrency())
+                .paymentMethod(payment.getPaymentMethod().name())
+                .paymentGateway(payment.getPaymentGateway())
+                .paymentStatus(payment.getPaymentStatus().name())
+                .tokenAmount(payment.getTokenAmount())
+                .paymentApprovedAt(payment.getPaymentApprovedAt())
+                .createdAt(payment.getCreatedAt())
+                .build();
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/token/dto/charge/PaymentResponse.java
+++ b/back/moya/src/main/java/com/study/moya/token/dto/charge/PaymentResponse.java
@@ -1,0 +1,16 @@
+package com.study.moya.token.dto.charge;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentResponse {
+    private String orderId;
+    private String paymentStatus;
+    private Long tokenAmount;
+}

--- a/back/moya/src/main/java/com/study/moya/token/dto/charge/TokenPackageDto.java
+++ b/back/moya/src/main/java/com/study/moya/token/dto/charge/TokenPackageDto.java
@@ -1,0 +1,31 @@
+package com.study.moya.token.dto.charge;
+
+import com.study.moya.token.domain.TokenPackage;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenPackageDto {
+    private Long id;
+    private String packageName;
+    private Long tokenAmount;
+    private Long price;
+    private String currency;
+    private Boolean isActive;
+
+    public static TokenPackageDto from(TokenPackage tokenPackage) {
+        return TokenPackageDto.builder()
+                .id(tokenPackage.getId())
+                .packageName(tokenPackage.getPackageName())
+                .tokenAmount(tokenPackage.getTokenAmount())
+                .price(tokenPackage.getPrice())
+                .currency(tokenPackage.getCurrency())
+                .isActive(tokenPackage.getIsActive())
+                .build();
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/token/dto/charge/TokenPackageResponse.java
+++ b/back/moya/src/main/java/com/study/moya/token/dto/charge/TokenPackageResponse.java
@@ -1,0 +1,16 @@
+package com.study.moya.token.dto.charge;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenPackageResponse {
+    private List<TokenPackageDto> availablePackages;
+}

--- a/back/moya/src/main/java/com/study/moya/token/dto/transaction/TokenTransactionDto.java
+++ b/back/moya/src/main/java/com/study/moya/token/dto/transaction/TokenTransactionDto.java
@@ -1,0 +1,49 @@
+package com.study.moya.token.dto.transaction;
+
+import com.study.moya.token.domain.TokenTransaction;
+import com.study.moya.token.domain.enums.PaymentMethod;
+import com.study.moya.token.domain.enums.TransactionType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenTransactionDto {
+    private Long id;
+    private Long tokenAccountId;
+    private Long memberId;
+    private Long paymentId;
+    private String orderId;
+    private Long aiUsageId;
+    private Long amount;
+    private TransactionType transactionType;
+    private PaymentMethod paymentMethod; // 결제 방법 추가
+    private Long balanceAfter;
+    private String description;
+    private String createdBy;
+    private LocalDateTime createdAt;
+
+    public static TokenTransactionDto from(TokenTransaction transaction) {
+        return TokenTransactionDto.builder()
+                .id(transaction.getId())
+                .tokenAccountId(transaction.getTokenAccount().getId())
+                .memberId(transaction.getTokenAccount().getMember().getId())
+                .paymentId(transaction.getPayment() != null ? transaction.getPayment().getId() : null)
+                .orderId(transaction.getPayment() != null ? transaction.getPayment().getOrderId() : null)
+                .aiUsageId(transaction.getAiUsage() != null ? transaction.getAiUsage().getId() : null)
+                .amount(transaction.getAmount())
+                .transactionType(transaction.getTransactionType())
+                .paymentMethod(transaction.getPaymentMethod()) // 결제 방법 추가
+                .balanceAfter(transaction.getBalanceAfter())
+                .description(transaction.getDescription())
+                .createdBy(transaction.getCreatedBy())
+                .createdAt(transaction.getCreatedAt())
+                .build();
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/token/dto/usage/AiServiceDto.java
+++ b/back/moya/src/main/java/com/study/moya/token/dto/usage/AiServiceDto.java
@@ -1,0 +1,29 @@
+package com.study.moya.token.dto.usage;
+
+import com.study.moya.token.domain.AiService;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AiServiceDto {
+    private Long id;
+    private String serviceName;
+    private String serviceType;
+    private Long tokenCost;
+    private Boolean isActive;
+
+    public static AiServiceDto from(AiService aiService) {
+        return AiServiceDto.builder()
+                .id(aiService.getId())
+                .serviceName(aiService.getServiceName())
+                .serviceType(aiService.getServiceType().name())
+                .tokenCost(aiService.getTokenCost())
+                .isActive(aiService.getIsActive())
+                .build();
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/token/dto/usage/AiServiceResponse.java
+++ b/back/moya/src/main/java/com/study/moya/token/dto/usage/AiServiceResponse.java
@@ -1,0 +1,16 @@
+package com.study.moya.token.dto.usage;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AiServiceResponse {
+    private List<AiServiceDto> availableServices;
+}

--- a/back/moya/src/main/java/com/study/moya/token/dto/usage/AiUsageDto.java
+++ b/back/moya/src/main/java/com/study/moya/token/dto/usage/AiUsageDto.java
@@ -1,0 +1,37 @@
+package com.study.moya.token.dto.usage;
+
+import com.study.moya.token.domain.AiUsage;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AiUsageDto {
+    private Long id;
+    private Long memberId;
+    private Long serviceId;
+    private String serviceName;
+    private String requestData;
+    private Long tokenCost;
+    private String status;
+    private LocalDateTime createdAt;
+
+    public static AiUsageDto from(AiUsage aiUsage) {
+        return AiUsageDto.builder()
+                .id(aiUsage.getId())
+                .memberId(aiUsage.getMember().getId())
+                .serviceId(aiUsage.getAiService().getId())
+                .serviceName(aiUsage.getAiService().getServiceName())
+                .requestData(aiUsage.getRequestData())
+                .tokenCost(aiUsage.getTokenCost())
+                .status(aiUsage.getStatus().name())
+                .createdAt(aiUsage.getCreatedAt())
+                .build();
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/token/dto/usage/AiUsageResponse.java
+++ b/back/moya/src/main/java/com/study/moya/token/dto/usage/AiUsageResponse.java
@@ -1,0 +1,17 @@
+package com.study.moya.token.dto.usage;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AiUsageResponse {
+    private Long id;
+    private String serviceName;
+    private Long tokenCost;
+    private String status;
+}

--- a/back/moya/src/main/java/com/study/moya/token/dto/usage/UseTokenRequest.java
+++ b/back/moya/src/main/java/com/study/moya/token/dto/usage/UseTokenRequest.java
@@ -1,0 +1,15 @@
+package com.study.moya.token.dto.usage;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UseTokenRequest {
+    private Long aiServiceId;
+    private String requestData;
+}

--- a/back/moya/src/main/java/com/study/moya/token/exception/TokenErrorCode.java
+++ b/back/moya/src/main/java/com/study/moya/token/exception/TokenErrorCode.java
@@ -1,0 +1,33 @@
+package com.study.moya.token.exception;
+
+import com.study.moya.error.constants.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum TokenErrorCode implements ErrorCode {
+    INSUFFICIENT_TOKEN(HttpStatus.BAD_REQUEST, "001", "토큰 잔액이 부족합니다"),
+    TOKEN_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "002", "토큰 계정이 존재하지 않습니다"),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "003", "회원이 존재하지 않습니다"),
+    TOKEN_PACKAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "004", "토큰 패키지가 존재하지 않습니다"),
+    TOKEN_PACKAGE_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "005", "비활성화된 토큰 패키지입니다"),
+    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "006", "결제 정보가 존재하지 않습니다"),
+    PAYMENT_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "007", "이미 처리된 결제입니다"),
+    AI_SERVICE_NOT_FOUND(HttpStatus.NOT_FOUND, "008", "AI 서비스가 존재하지 않습니다"),
+    AI_SERVICE_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "009", "비활성화된 AI 서비스입니다"),
+    AI_USAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "010", "AI 사용 내역이 존재하지 않습니다"),
+    TRANSACTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "011", "토큰 거래 처리 중 오류가 발생했습니다"),
+    PAYMENT_PROCESSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "012", "결제 처리 중 오류가 발생했습니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+    private static final String PREFIX = "TOKEN";
+
+    @Override
+    public String getFullCode() {
+        return PREFIX + "_" + code;
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/token/exception/TokenException.java
+++ b/back/moya/src/main/java/com/study/moya/token/exception/TokenException.java
@@ -1,0 +1,14 @@
+package com.study.moya.token.exception;
+
+import com.study.moya.error.exception.BaseException;
+
+public class TokenException extends BaseException {
+
+    protected TokenException(TokenErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public static TokenException of(TokenErrorCode errorCode) {
+        return new TokenException(errorCode);
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/token/repository/AiServiceRepository.java
+++ b/back/moya/src/main/java/com/study/moya/token/repository/AiServiceRepository.java
@@ -1,0 +1,18 @@
+package com.study.moya.token.repository;
+
+import com.study.moya.token.domain.AiService;
+import com.study.moya.token.domain.enums.AiServiceType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface AiServiceRepository extends JpaRepository<AiService, Long> {
+    Optional<AiService> findByServiceNameAndIsActiveTrue(String serviceName);
+
+    List<AiService> findByIsActiveTrueOrderByTokenCostAsc();
+
+    List<AiService> findByServiceTypeAndIsActiveTrue(AiServiceType serviceType);
+}

--- a/back/moya/src/main/java/com/study/moya/token/repository/AiUsageRepository.java
+++ b/back/moya/src/main/java/com/study/moya/token/repository/AiUsageRepository.java
@@ -1,0 +1,26 @@
+package com.study.moya.token.repository;
+
+import com.study.moya.member.domain.Member;
+import com.study.moya.token.domain.AiService;
+import com.study.moya.token.domain.AiUsage;
+import com.study.moya.token.domain.enums.AiUsageStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface AiUsageRepository extends JpaRepository<AiUsage, Long> {
+    Page<AiUsage> findByMemberOrderByCreatedAtDesc(Member member, Pageable pageable);
+
+    List<AiUsage> findByMemberAndAiServiceAndCreatedAtBetween(
+            Member member,
+            AiService aiService,
+            LocalDateTime startDate,
+            LocalDateTime endDate);
+
+    List<AiUsage> findByStatusOrderByCreatedAtAsc(AiUsageStatus status);
+}

--- a/back/moya/src/main/java/com/study/moya/token/repository/PaymentRepository.java
+++ b/back/moya/src/main/java/com/study/moya/token/repository/PaymentRepository.java
@@ -1,0 +1,20 @@
+package com.study.moya.token.repository;
+
+import com.study.moya.member.domain.Member;
+import com.study.moya.token.domain.Payment;
+import com.study.moya.token.domain.enums.PaymentStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+    Optional<Payment> findByOrderId(String orderId);
+
+    Page<Payment> findByMemberOrderByCreatedAtDesc(Member member, Pageable pageable);
+
+    boolean existsByOrderIdAndPaymentStatus(String orderId, PaymentStatus status);
+}

--- a/back/moya/src/main/java/com/study/moya/token/repository/TokenAccountRepository.java
+++ b/back/moya/src/main/java/com/study/moya/token/repository/TokenAccountRepository.java
@@ -1,0 +1,20 @@
+package com.study.moya.token.repository;
+
+import com.study.moya.member.domain.Member;
+import com.study.moya.token.domain.TokenAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.stereotype.Repository;
+
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
+
+@Repository
+public interface TokenAccountRepository extends JpaRepository<TokenAccount, Long> {
+    Optional<TokenAccount> findByMember(Member member);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<TokenAccount> findWithLockById(Long id);
+
+    boolean existsByMemberId(Long memberId);
+}

--- a/back/moya/src/main/java/com/study/moya/token/repository/TokenPackageRepository.java
+++ b/back/moya/src/main/java/com/study/moya/token/repository/TokenPackageRepository.java
@@ -1,0 +1,14 @@
+package com.study.moya.token.repository;
+
+import com.study.moya.token.domain.TokenPackage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TokenPackageRepository extends JpaRepository<TokenPackage, Long> {
+    List<TokenPackage> findByIsActiveTrue();
+
+    List<TokenPackage> findByIsActiveTrueOrderByPriceAsc();
+}

--- a/back/moya/src/main/java/com/study/moya/token/repository/TokenTransactionRepository.java
+++ b/back/moya/src/main/java/com/study/moya/token/repository/TokenTransactionRepository.java
@@ -1,0 +1,30 @@
+package com.study.moya.token.repository;
+
+import com.study.moya.token.domain.TokenAccount;
+import com.study.moya.token.domain.TokenTransaction;
+import com.study.moya.token.domain.enums.TransactionType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface TokenTransactionRepository extends JpaRepository<TokenTransaction, Long> {
+    Page<TokenTransaction> findByTokenAccountOrderByCreatedAtDesc(TokenAccount tokenAccount, Pageable pageable);
+
+    Page<TokenTransaction> findByTokenAccountIdOrderByCreatedAtDesc(Long tokenAccountId, Pageable pageable);
+
+    List<TokenTransaction> findByTokenAccountAndTransactionTypeAndCreatedAtBetween(
+            TokenAccount tokenAccount,
+            TransactionType transactionType,
+            LocalDateTime startDate,
+            LocalDateTime endDate);
+
+    List<TokenTransaction> findByTokenAccountIdAndCreatedAtBetweenOrderByCreatedAtDesc(
+            Long tokenAccountId,
+            LocalDateTime startDate,
+            LocalDateTime endDate);
+}

--- a/back/moya/src/main/java/com/study/moya/token/service/TokenAccountService.java
+++ b/back/moya/src/main/java/com/study/moya/token/service/TokenAccountService.java
@@ -1,0 +1,115 @@
+package com.study.moya.token.service;
+
+import com.study.moya.member.domain.Member;
+import com.study.moya.member.repository.MemberRepository;
+import com.study.moya.token.domain.TokenAccount;
+import com.study.moya.token.dto.account.TokenAccountDto;
+import com.study.moya.token.dto.account.TokenBalanceResponse;
+import com.study.moya.token.dto.transaction.TokenTransactionDto;
+import com.study.moya.token.exception.TokenErrorCode;
+import com.study.moya.token.exception.TokenException;
+import com.study.moya.token.repository.TokenAccountRepository;
+import com.study.moya.token.repository.TokenTransactionRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 토큰 계정 관련 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TokenAccountService {
+
+    private final MemberRepository memberRepository;
+    private final TokenAccountRepository tokenAccountRepository;
+    private final TokenTransactionRepository tokenTransactionRepository;
+
+    /**
+     * 회원의 토큰 계정을 조회하거나 없으면 생성합니다.
+     */
+    @Transactional
+    public TokenAccountDto getOrCreateTokenAccount(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> TokenException.of(TokenErrorCode.MEMBER_NOT_FOUND));
+
+        TokenAccount tokenAccount = tokenAccountRepository.findByMember(member)
+                .orElseGet(() -> {
+                    // 빌더 패턴을 사용하여 TokenAccount 객체 생성
+                    TokenAccount newAccount = TokenAccount.builder()
+                            .member(member)
+                            .balance(0L)  // 초기 잔액 0으로 설정
+                            .build();
+
+                    return tokenAccountRepository.save(newAccount);
+                });
+
+        return TokenAccountDto.from(tokenAccount);
+    }
+
+    /**
+     * 회원의 토큰 잔액 및 최근 거래 내역을 조회합니다.
+     */
+    public TokenBalanceResponse getTokenBalance(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> TokenException.of(TokenErrorCode.MEMBER_NOT_FOUND));
+
+        TokenAccount tokenAccount = tokenAccountRepository.findByMember(member)
+                .orElseThrow(() -> TokenException.of(TokenErrorCode.TOKEN_ACCOUNT_NOT_FOUND));
+
+        List<TokenTransactionDto> recentTransactions = tokenTransactionRepository
+                .findByTokenAccountIdAndCreatedAtBetweenOrderByCreatedAtDesc(
+                        tokenAccount.getId(),
+                        LocalDateTime.now().minusDays(30),
+                        LocalDateTime.now()
+                )
+                .stream()
+                .map(TokenTransactionDto::from)
+                .collect(Collectors.toList());
+
+        return TokenBalanceResponse.builder()
+                .balance(tokenAccount.getBalance())
+                .recentTransactions(recentTransactions)
+                .build();
+    }
+
+    /**
+     * 회원의 토큰 잔액 업데이트 (충전)
+     */
+    @Transactional
+    public Long addTokens(Long accountId, Long amount) {
+        TokenAccount tokenAccount = tokenAccountRepository.findById(accountId)
+                .orElseThrow(() -> TokenException.of(TokenErrorCode.TOKEN_ACCOUNT_NOT_FOUND));
+
+        tokenAccount.addTokens(amount);
+        TokenAccount savedAccount = tokenAccountRepository.save(tokenAccount);
+
+        return savedAccount.getBalance();
+    }
+
+    /**
+     * 회원의 토큰 잔액 업데이트 (사용)
+     */
+    @Transactional
+    public Long useTokens(Long accountId, Long amount) {
+        TokenAccount tokenAccount = tokenAccountRepository.findById(accountId)
+                .orElseThrow(() -> TokenException.of(TokenErrorCode.TOKEN_ACCOUNT_NOT_FOUND));
+
+        // 서비스 계층에서 잔액 검증 수행
+        if (!tokenAccount.hasEnoughTokens(amount)) {
+            throw TokenException.of(TokenErrorCode.INSUFFICIENT_TOKEN);
+        }
+
+        // 검증 후 토큰 사용 처리
+        tokenAccount.useTokens(amount);
+        TokenAccount savedAccount = tokenAccountRepository.save(tokenAccount);
+
+        return savedAccount.getBalance();
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/token/service/TokenChargeService.java
+++ b/back/moya/src/main/java/com/study/moya/token/service/TokenChargeService.java
@@ -1,0 +1,136 @@
+package com.study.moya.token.service;
+
+import com.study.moya.member.domain.Member;
+import com.study.moya.member.repository.MemberRepository;
+import com.study.moya.token.domain.enums.PaymentMethod;
+import com.study.moya.token.domain.enums.PaymentStatus;
+import com.study.moya.token.domain.Payment;
+import com.study.moya.token.domain.TokenAccount;
+import com.study.moya.token.domain.TokenPackage;
+import com.study.moya.token.dto.charge.ChargeTokenRequest;
+import com.study.moya.token.dto.charge.PaymentConfirmRequest;
+import com.study.moya.token.dto.charge.PaymentResponse;
+import com.study.moya.token.dto.charge.TokenPackageDto;
+import com.study.moya.token.dto.charge.TokenPackageResponse;
+import com.study.moya.token.exception.TokenErrorCode;
+import com.study.moya.token.exception.TokenException;
+import com.study.moya.token.repository.PaymentRepository;
+import com.study.moya.token.repository.TokenAccountRepository;
+import com.study.moya.token.repository.TokenPackageRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * 토큰 충전 관련 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TokenChargeService {
+
+    private final MemberRepository memberRepository;
+    private final TokenAccountRepository tokenAccountRepository;
+    private final TokenPackageRepository tokenPackageRepository;
+    private final PaymentRepository paymentRepository;
+    private final TokenAccountService tokenAccountService;
+    private final TokenTransactionService tokenTransactionService;
+
+    /**
+     * 사용 가능한 토큰 패키지 목록 조회
+     */
+    public TokenPackageResponse getAvailableTokenPackages() {
+        List<TokenPackage> packages = tokenPackageRepository.findByIsActiveTrueOrderByPriceAsc();
+
+        return TokenPackageResponse.builder()
+                .availablePackages(packages.stream()
+                        .map(TokenPackageDto::from)
+                        .collect(Collectors.toList()))
+                .build();
+    }
+
+    /**
+     * 토큰 충전 요청
+     */
+    @Transactional
+    public PaymentResponse requestTokenCharge(Long memberId, ChargeTokenRequest request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> TokenException.of(TokenErrorCode.MEMBER_NOT_FOUND));
+
+        TokenPackage tokenPackage = tokenPackageRepository.findById(request.getTokenPackageId())
+                .orElseThrow(() -> TokenException.of(TokenErrorCode.TOKEN_PACKAGE_NOT_FOUND));
+
+        if (!tokenPackage.getIsActive()) {
+            throw TokenException.of(TokenErrorCode.TOKEN_PACKAGE_NOT_ACTIVE);
+        }
+
+        // 주문 ID 생성
+        String orderId = UUID.randomUUID().toString();
+
+        // 결제 정보 생성 (Builder 패턴 사용)
+        Payment payment = Payment.builder()
+                .member(member)
+                .orderId(orderId)
+                .amount(tokenPackage.getPrice())
+                .currency(tokenPackage.getCurrency())
+                .paymentMethod(PaymentMethod.valueOf(request.getPaymentMethod()))
+                .paymentStatus(PaymentStatus.PENDING)
+                .tokenAmount(tokenPackage.getTokenAmount())
+                .build();
+
+        Payment savedPayment = paymentRepository.save(payment);
+
+        return PaymentResponse.builder()
+                .orderId(savedPayment.getOrderId())
+                .paymentStatus(savedPayment.getPaymentStatus().name())
+                .tokenAmount(savedPayment.getTokenAmount())
+                .build();
+    }
+
+    /**
+     * 결제 확인 및 토큰 충전 처리
+     */
+    @Transactional
+    public PaymentResponse confirmPayment(PaymentConfirmRequest request) {
+        Payment payment = paymentRepository.findByOrderId(request.getOrderId())
+                .orElseThrow(() -> TokenException.of(TokenErrorCode.PAYMENT_NOT_FOUND));
+
+        if (payment.getPaymentStatus() == PaymentStatus.COMPLETED) {
+            throw TokenException.of(TokenErrorCode.PAYMENT_ALREADY_PROCESSED);
+        }
+
+        PaymentStatus newStatus = PaymentStatus.valueOf(request.getPaymentStatus());
+        payment.updatePaymentStatus(newStatus);
+
+        if (newStatus == PaymentStatus.COMPLETED) {
+            payment.completePayment();
+
+            // 토큰 계정에 토큰 추가
+            TokenAccount tokenAccount = tokenAccountRepository.findByMember(payment.getMember())
+                    .orElseThrow(() -> TokenException.of(TokenErrorCode.TOKEN_ACCOUNT_NOT_FOUND));
+
+            // 토큰 계정 업데이트
+            Long newBalance = tokenAccountService.addTokens(tokenAccount.getId(), payment.getTokenAmount());
+
+            // 트랜잭션 기록
+            tokenTransactionService.createChargeTransaction(tokenAccount.getId(), payment, payment.getTokenAmount());
+
+            log.info("토큰 충전 완료: 회원 ID {}, 주문 ID {}, 충전 토큰 {}, 새 잔액 {}",
+                    payment.getMember().getId(), payment.getOrderId(), payment.getTokenAmount(), newBalance);
+        }
+
+        Payment updatedPayment = paymentRepository.save(payment);
+
+        return PaymentResponse.builder()
+                .orderId(updatedPayment.getOrderId())
+                .paymentStatus(updatedPayment.getPaymentStatus().name())
+                .tokenAmount(updatedPayment.getTokenAmount())
+                .build();
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/token/service/TokenFacadeService.java
+++ b/back/moya/src/main/java/com/study/moya/token/service/TokenFacadeService.java
@@ -1,0 +1,149 @@
+package com.study.moya.token.service;
+
+import com.study.moya.token.dto.account.TokenAccountDto;
+import com.study.moya.token.dto.account.TokenBalanceResponse;
+import com.study.moya.token.dto.charge.ChargeTokenRequest;
+import com.study.moya.token.dto.charge.PaymentConfirmRequest;
+import com.study.moya.token.dto.charge.PaymentResponse;
+import com.study.moya.token.dto.charge.TokenPackageResponse;
+import com.study.moya.token.dto.transaction.TokenTransactionDto;
+import com.study.moya.token.dto.usage.AiServiceResponse;
+import com.study.moya.token.dto.usage.AiUsageDto;
+import com.study.moya.token.dto.usage.AiUsageResponse;
+import com.study.moya.token.dto.usage.UseTokenRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 토큰 서비스 퍼사드 - 여러 서비스를 통합하여 컨트롤러에 단일 인터페이스 제공
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TokenFacadeService {
+
+    private final TokenAccountService tokenAccountService;
+    private final TokenTransactionService tokenTransactionService;
+    private final TokenChargeService tokenChargeService;
+    private final TokenUsageService tokenUsageService;
+
+    /**
+     * 회원의 토큰 계정을 조회하거나 없으면 생성합니다.
+     */
+    public TokenAccountDto getOrCreateTokenAccount(Long memberId) {
+        return tokenAccountService.getOrCreateTokenAccount(memberId);
+    }
+
+    /**
+     * 회원의 토큰 잔액 및 최근 거래 내역을 조회합니다.
+     */
+    public TokenBalanceResponse getTokenBalance(Long memberId) {
+
+        getOrCreateTokenAccount(memberId);
+        return tokenAccountService.getTokenBalance(memberId);
+    }
+
+    /**
+     * 사용 가능한 토큰 패키지 목록 조회
+     */
+    public TokenPackageResponse getAvailableTokenPackages() {
+        return tokenChargeService.getAvailableTokenPackages();
+    }
+
+    /**
+     * 토큰 충전 요청
+     */
+    public PaymentResponse requestTokenCharge(Long memberId, ChargeTokenRequest request) {
+        return tokenChargeService.requestTokenCharge(memberId, request);
+    }
+
+    /**
+     * 결제 확인 및 토큰 충전 처리
+     */
+    public PaymentResponse confirmPayment(PaymentConfirmRequest request) {
+        return tokenChargeService.confirmPayment(request);
+    }
+
+    /**
+     * 사용 가능한 AI 서비스 목록 조회
+     */
+    public AiServiceResponse getAvailableAiServices() {
+        return tokenUsageService.getAvailableAiServices();
+    }
+
+    /**
+     * 특정 유형의 사용 가능한 AI 서비스 목록 조회
+     */
+    public AiServiceResponse getAvailableAiServicesByType(String serviceType) {
+        return tokenUsageService.getAvailableAiServicesByType(serviceType);
+    }
+
+    /**
+     * AI 서비스 사용 및 토큰 차감
+     */
+    public AiUsageResponse useTokenForAiService(Long memberId, UseTokenRequest request) {
+        return tokenUsageService.useTokenForAiService(memberId, request);
+    }
+
+    /**
+     * 회원의 트랜잭션 내역 조회 (페이징)
+     */
+    public Page<TokenTransactionDto> getMemberTransactions(Long memberId, Pageable pageable) {
+        return tokenTransactionService.getMemberTransactions(memberId, pageable);
+    }
+
+    /**
+     * 특정 기간 동안의 회원 트랜잭션 내역 조회
+     */
+    public List<TokenTransactionDto> getMemberTransactionsBetween(Long memberId, LocalDateTime start, LocalDateTime end) {
+        return tokenTransactionService.getMemberTransactionsBetween(memberId, start, end);
+    }
+
+    /**
+     * 회원의 AI 사용 내역 조회 (페이징)
+     */
+    public Page<AiUsageDto> getMemberAiUsages(Long memberId, Pageable pageable) {
+        return tokenUsageService.getMemberAiUsages(memberId, pageable);
+    }
+
+    /**
+     * 특정 기간 동안의 회원 AI 사용 내역 조회
+     */
+    public List<AiUsageDto> getMemberAiUsagesBetween(Long memberId, LocalDateTime start, LocalDateTime end) {
+        return tokenUsageService.getMemberAiUsagesBetween(memberId, start, end);
+    }
+
+    /**
+     * 대기 중인 AI 사용 내역 처리 (배치 작업)
+     */
+    public void processAiUsageResults() {
+        tokenUsageService.processAiUsageResults();
+    }
+
+    /**
+     * AI 사용 내역을 완료 상태로 변경
+     */
+    public void markAiUsageAsCompleted(Long usageId) {
+        tokenUsageService.markAiUsageAsCompleted(usageId);
+    }
+
+    /**
+     * AI 사용 내역을 실패 상태로 변경하고 토큰 환불 처리
+     */
+    public void markAiUsageAsFailed(Long usageId) {
+        tokenUsageService.markAiUsageAsFailed(usageId);
+    }
+
+    /**
+     * 실제 토큰 사용량 업데이트
+     */
+    public void updateActualTokenUsage(Long usageId, Long actualTokenUsage) {
+        tokenUsageService.updateActualTokenUsage(usageId, actualTokenUsage);
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/token/service/TokenTransactionService.java
+++ b/back/moya/src/main/java/com/study/moya/token/service/TokenTransactionService.java
@@ -1,0 +1,122 @@
+package com.study.moya.token.service;
+
+import com.study.moya.token.domain.AiUsage;
+import com.study.moya.token.domain.Payment;
+import com.study.moya.token.domain.TokenAccount;
+import com.study.moya.token.domain.TokenTransaction;
+import com.study.moya.token.domain.enums.PaymentMethod;
+import com.study.moya.token.domain.enums.TransactionType;
+import com.study.moya.token.dto.transaction.TokenTransactionDto;
+import com.study.moya.token.exception.TokenErrorCode;
+import com.study.moya.token.exception.TokenException;
+import com.study.moya.token.repository.TokenAccountRepository;
+import com.study.moya.token.repository.TokenTransactionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TokenTransactionService {
+
+    private final TokenTransactionRepository tokenTransactionRepository;
+    private final TokenAccountRepository tokenAccountRepository;
+
+    @Transactional
+    public TokenTransaction createChargeTransaction(Long tokenAccountId, Payment payment, Long amount) {
+        TokenAccount tokenAccount = tokenAccountRepository.findById(tokenAccountId)
+                .orElseThrow(() -> TokenException.of(TokenErrorCode.TOKEN_ACCOUNT_NOT_FOUND));
+
+        TokenTransaction transaction = TokenTransaction.builder()
+                .tokenAccount(tokenAccount)
+                .payment(payment)
+                .amount(amount)
+                .transactionType(TransactionType.CHARGE)
+                .paymentMethod(payment.getPaymentMethod()) // 결제 방법 추가
+                .balanceAfter(tokenAccount.getBalance())
+                .description("토큰 충전: " + payment.getPaymentMethod().name() + " 결제")
+                .createdBy("SYSTEM")
+                .build();
+
+        return tokenTransactionRepository.save(transaction);
+    }
+
+    @Transactional
+    public TokenTransaction createUsageTransaction(Long tokenAccountId, AiUsage aiUsage, Long amount) {
+        TokenAccount tokenAccount = tokenAccountRepository.findById(tokenAccountId)
+                .orElseThrow(() -> TokenException.of(TokenErrorCode.TOKEN_ACCOUNT_NOT_FOUND));
+
+        TokenTransaction transaction = TokenTransaction.builder()
+                .tokenAccount(tokenAccount)
+                .aiUsage(aiUsage)
+                .amount(amount)
+                .transactionType(TransactionType.USAGE)
+                .paymentMethod(null) // AI 사용에는 결제 방법이 없음
+                .balanceAfter(tokenAccount.getBalance())
+                .description("AI 서비스 사용: " + aiUsage.getAiService().getServiceName())
+                .createdBy("SYSTEM")
+                .build();
+
+        return tokenTransactionRepository.save(transaction);
+    }
+
+    @Transactional
+    public TokenTransaction createRefundTransaction(Long tokenAccountId, AiUsage aiUsage, Long amount) {
+        TokenAccount tokenAccount = tokenAccountRepository.findById(tokenAccountId)
+                .orElseThrow(() -> TokenException.of(TokenErrorCode.TOKEN_ACCOUNT_NOT_FOUND));
+
+        TokenTransaction transaction = TokenTransaction.builder()
+                .tokenAccount(tokenAccount)
+                .aiUsage(aiUsage)
+                .amount(amount)
+                .transactionType(TransactionType.REFUND)
+                .paymentMethod(null) // 환불에는 결제 방법이 없음
+                .balanceAfter(tokenAccount.getBalance())
+                .description("AI 서비스 사용 취소 환불: " + aiUsage.getAiService().getServiceName())
+                .createdBy("SYSTEM")
+                .build();
+
+        return tokenTransactionRepository.save(transaction);
+    }
+
+    @Transactional
+    public TokenTransaction createAdminTransaction(Long tokenAccountId, Long amount, String description, PaymentMethod paymentMethod) {
+        TokenAccount tokenAccount = tokenAccountRepository.findById(tokenAccountId)
+                .orElseThrow(() -> TokenException.of(TokenErrorCode.TOKEN_ACCOUNT_NOT_FOUND));
+
+        TransactionType type = amount >= 0 ? TransactionType.ADMIN_CHARGE : TransactionType.ADMIN_DEDUCT;
+
+        TokenTransaction transaction = TokenTransaction.builder()
+                .tokenAccount(tokenAccount)
+                .amount(Math.abs(amount))
+                .transactionType(type)
+                .paymentMethod(paymentMethod) // 관리자 트랜잭션에도 결제 방법 설정 가능
+                .balanceAfter(tokenAccount.getBalance())
+                .description(description)
+                .createdBy("ADMIN")
+                .build();
+
+        return tokenTransactionRepository.save(transaction);
+    }
+
+    public Page<TokenTransactionDto> getMemberTransactions(Long tokenAccountId, Pageable pageable) {
+        return tokenTransactionRepository.findByTokenAccountIdOrderByCreatedAtDesc(tokenAccountId, pageable)
+                .map(TokenTransactionDto::from);
+    }
+
+    public List<TokenTransactionDto> getMemberTransactionsBetween(Long tokenAccountId, LocalDateTime start, LocalDateTime end) {
+        return tokenTransactionRepository.findByTokenAccountIdAndCreatedAtBetweenOrderByCreatedAtDesc(
+                        tokenAccountId, start, end)
+                .stream()
+                .map(TokenTransactionDto::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/token/service/TokenUsageService.java
+++ b/back/moya/src/main/java/com/study/moya/token/service/TokenUsageService.java
@@ -1,0 +1,236 @@
+package com.study.moya.token.service;
+
+import com.study.moya.member.domain.Member;
+import com.study.moya.member.repository.MemberRepository;
+import com.study.moya.token.domain.AiService;
+import com.study.moya.token.domain.AiUsage;
+import com.study.moya.token.domain.TokenAccount;
+import com.study.moya.token.domain.enums.AiServiceType;
+import com.study.moya.token.domain.enums.AiUsageStatus;
+import com.study.moya.token.dto.usage.AiServiceDto;
+import com.study.moya.token.dto.usage.AiServiceResponse;
+import com.study.moya.token.dto.usage.AiUsageDto;
+import com.study.moya.token.dto.usage.AiUsageResponse;
+import com.study.moya.token.dto.usage.UseTokenRequest;
+import com.study.moya.token.exception.TokenErrorCode;
+import com.study.moya.token.exception.TokenException;
+import com.study.moya.token.repository.AiServiceRepository;
+import com.study.moya.token.repository.AiUsageRepository;
+import com.study.moya.token.repository.TokenAccountRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * AI 서비스 사용 관련 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TokenUsageService {
+
+    private final MemberRepository memberRepository;
+    private final TokenAccountRepository tokenAccountRepository;
+    private final AiServiceRepository aiServiceRepository;
+    private final AiUsageRepository aiUsageRepository;
+    private final TokenAccountService tokenAccountService;
+    private final TokenTransactionService tokenTransactionService;
+
+    /**
+     * 사용 가능한 AI 서비스 목록 조회
+     */
+    public AiServiceResponse getAvailableAiServices() {
+        List<AiService> services = aiServiceRepository.findByIsActiveTrueOrderByTokenCostAsc();
+
+        return AiServiceResponse.builder()
+                .availableServices(services.stream()
+                        .map(AiServiceDto::from)
+                        .collect(Collectors.toList()))
+                .build();
+    }
+
+    /**
+     * 특정 유형의 사용 가능한 AI 서비스 목록 조회
+     */
+    public AiServiceResponse getAvailableAiServicesByType(String serviceType) {
+        AiServiceType type = AiServiceType.valueOf(serviceType);
+        List<AiService> services = aiServiceRepository.findByServiceTypeAndIsActiveTrue(type);
+
+        return AiServiceResponse.builder()
+                .availableServices(services.stream()
+                        .map(AiServiceDto::from)
+                        .collect(Collectors.toList()))
+                .build();
+    }
+
+    /**
+     * AI 서비스 사용 및 토큰 차감
+     */
+    @Transactional
+    public AiUsageResponse useTokenForAiService(Long memberId, UseTokenRequest request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> TokenException.of(TokenErrorCode.MEMBER_NOT_FOUND));
+
+        AiService aiService = aiServiceRepository.findById(request.getAiServiceId())
+                .orElseThrow(() -> TokenException.of(TokenErrorCode.AI_SERVICE_NOT_FOUND));
+
+        // 고정 토큰 비용 사용
+        Long tokenCost = aiService.getTokenCost();
+
+        // 토큰 계정 조회
+        TokenAccount tokenAccount = tokenAccountRepository.findByMember(member)
+                .orElseThrow(() -> TokenException.of(TokenErrorCode.TOKEN_ACCOUNT_NOT_FOUND));
+
+        // 잔액 확인
+        if (tokenAccount.getBalance() < tokenCost) {
+            throw TokenException.of(TokenErrorCode.INSUFFICIENT_TOKEN);
+        }
+
+        // 토큰 차감 (낙관적 락 적용)
+        Long newBalance = tokenAccountService.useTokens(tokenAccount.getId(), tokenCost);
+
+        // AI 사용 내역 생성
+        AiUsage aiUsage = AiUsage.builder()
+                .member(member)
+                .aiService(aiService)
+                .requestData(request.getRequestData())
+                .tokenCost(tokenCost)
+                .status(AiUsageStatus.PENDING)
+                .build();
+
+        AiUsage savedUsage = aiUsageRepository.save(aiUsage);
+
+        // 트랜잭션 기록
+        tokenTransactionService.createUsageTransaction(
+                tokenAccount.getId(), savedUsage, tokenCost);
+
+        return AiUsageResponse.builder()
+                .id(savedUsage.getId())
+                .serviceName(aiService.getServiceName())
+                .tokenCost(tokenCost)
+                .status(savedUsage.getStatus().name())
+                .build();
+    }
+
+    /**
+     * 회원의 AI 사용 내역 조회 (페이징)
+     */
+    public Page<AiUsageDto> getMemberAiUsages(Long memberId, Pageable pageable) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> TokenException.of(TokenErrorCode.MEMBER_NOT_FOUND));
+
+        return aiUsageRepository.findByMemberOrderByCreatedAtDesc(member, pageable)
+                .map(AiUsageDto::from);
+    }
+
+    /**
+     * 특정 기간 동안의 회원 AI 사용 내역 조회
+     */
+    public List<AiUsageDto> getMemberAiUsagesBetween(Long memberId, LocalDateTime start, LocalDateTime end) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> TokenException.of(TokenErrorCode.MEMBER_NOT_FOUND));
+
+        return aiUsageRepository.findByMemberAndAiServiceAndCreatedAtBetween(member, null, start, end)
+                .stream()
+                .map(AiUsageDto::from)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 대기 중인 AI 사용 내역 처리 (배치 작업)
+     */
+    @Transactional
+    public void processAiUsageResults() {
+        List<AiUsage> pendingUsages = aiUsageRepository.findByStatusOrderByCreatedAtAsc(AiUsageStatus.PENDING);
+
+        for (AiUsage usage : pendingUsages) {
+            try {
+                // 실제로는 여기서 AI 서비스 처리 결과를 확인하는 로직이 필요함
+                // 예시로 모든 요청이 성공했다고 가정
+                usage.completeUsage();
+                aiUsageRepository.save(usage);
+
+                log.info("AI 서비스 처리 완료: {}", usage.getId());
+            } catch (Exception e) {
+                log.error("AI 서비스 처리 실패: {}", usage.getId(), e);
+                usage.failUsage();
+                aiUsageRepository.save(usage);
+
+                // 실패한 경우 토큰 환불 처리
+                refundTokensForFailedUsage(usage);
+            }
+        }
+    }
+
+    /**
+     * 실패한 AI 사용에 대한 토큰 환불 처리
+     */
+    @Transactional
+    private void refundTokensForFailedUsage(AiUsage usage) {
+        TokenAccount tokenAccount = tokenAccountRepository.findByMember(usage.getMember())
+                .orElseThrow(() -> TokenException.of(TokenErrorCode.TOKEN_ACCOUNT_NOT_FOUND));
+
+        // 토큰 환불
+        Long newBalance = tokenAccountService.addTokens(tokenAccount.getId(), usage.getTokenCost());
+
+        // 환불 트랜잭션 기록
+        tokenTransactionService.createRefundTransaction(tokenAccount.getId(), usage, usage.getTokenCost());
+
+        log.info("토큰 환불 처리 완료: AI 사용 ID {}, 환불 토큰 {}, 새 잔액 {}",
+                usage.getId(), usage.getTokenCost(), newBalance);
+    }
+
+    /**
+     * 실제 사용한 토큰량 확인
+     */
+    @Transactional
+    public void updateActualTokenUsage(Long usageId, Long actualTokenUsage) {
+        AiUsage usage = aiUsageRepository.findById(usageId)
+                .orElseThrow(() -> TokenException.of(TokenErrorCode.AI_USAGE_NOT_FOUND));
+
+        usage.recordActualTokenUsage(actualTokenUsage);
+        aiUsageRepository.save(usage);
+
+        log.info("실제 토큰 사용량 업데이트: 사용 ID {}, 고정 비용 {}, 실제 사용 토큰 {}",
+                usageId, usage.getTokenCost(), actualTokenUsage);
+    }
+
+    /**
+     * AI 사용 내역을 완료 상태로 변경
+     */
+    @Transactional
+    public void markAiUsageAsCompleted(Long usageId) {
+        AiUsage usage = aiUsageRepository.findById(usageId)
+                .orElseThrow(() -> TokenException.of(TokenErrorCode.AI_USAGE_NOT_FOUND));
+
+        usage.completeUsage();
+        aiUsageRepository.save(usage);
+
+        log.info("AI 서비스 처리 완료 상태로 변경: {}", usage.getId());
+    }
+
+    /**
+     * AI 사용 내역을 실패 상태로 변경하고 토큰 환불 처리
+     */
+    @Transactional
+    public void markAiUsageAsFailed(Long usageId) {
+        AiUsage usage = aiUsageRepository.findById(usageId)
+                .orElseThrow(() -> TokenException.of(TokenErrorCode.AI_USAGE_NOT_FOUND));
+
+        // 실패 상태로 변경
+        usage.failUsage();
+        aiUsageRepository.save(usage);
+
+        // 토큰 환불 처리
+        refundTokensForFailedUsage(usage);
+
+        log.info("AI 서비스 처리 실패 상태로 변경 및 토큰 환불 처리: {}", usage.getId());
+    }
+}


### PR DESCRIPTION
AI 로드맵 서비스와 토큰 시스템 통합
🔍 PR 개요
OpenAI API를 사용하는 로드맵 및 워크시트 생성 서비스에 내부 토큰 시스템을 연동하여, 서비스 사용 시 회원의 토큰이 차감되고 사용량이 기록되는 기능을 구현했습니다. 고정 가격 모델을 적용하여 서비스별로 정해진 토큰 비용을 차감하고, 실제 사용량도 모니터링합니다.
📝 변경사항
토큰 시스템 아키텍처 설계 및 구현

OpenAI API의 토큰 사용량과 내부 토큰 시스템의 연동 방식 설계
고정 가격 모델 채택: AI 서비스별로 미리 정의된 토큰 비용 사용
실제 API 사용량 모니터링을 위한 필드 추가 및 로깅 기능 구현

AI 서비스 통합 구현

RoadmapService에 TokenFacadeService 통합
AiUsage 엔티티에 실제 토큰 사용량 필드 추가
토큰 차감, 사용 내역 기록, 실패 시 환불 처리 로직 구현

동시성 제어 구현

토큰 계정 엔티티에 낙관적 락(Optimistic Lock) 적용
동시 요청 시 충돌 처리 및 예외 핸들링 구현

🔗 관련 이슈

Close #123 AI 서비스에 토큰 시스템 연동

✅ 체크리스트
로컬 테스트

 로드맵 생성 시 토큰 차감 기능 테스트 완료
 API 호출 실패 시 환불 처리 테스트 완료
 실제 토큰 사용량 로깅 테스트 완료
 동시성 제어 테스트 완료

JPA 성능 최적화

 AiUsage 엔티티에 실제 사용량 필드 추가
 TokenAccount 엔티티에 낙관적 락을 위한 version 필드 추가
 관련 테이블 인덱스 최적화

DB 스키마 변경

 ai_usages 테이블 수정

sql복사-- ai_usages 테이블에 actual_token_usage 컬럼 추가
ALTER TABLE ai_usages ADD COLUMN actual_token_usage BIGINT;

-- token_accounts 테이블에 version 컬럼 추가 (낙관적 락용)
ALTER TABLE token_accounts ADD COLUMN version BIGINT DEFAULT 0;
🚨 주의사항
1. 설정 관련

ai_services 테이블에 로드맵 생성 서비스(ID: 1)와 워크시트 생성 서비스(ID: 2)가 등록되어 있어야 합니다.
각 서비스의 토큰 비용(tokenCost)을 적절히 설정해야 합니다.

2. 운영 관련

OpenAI API 모델 변경 시 토큰 사용량이 달라질 수 있으므로 모니터링이 필요합니다.
실제 토큰 사용량과 고정 비용의 차이를 정기적으로 분석하여 요금 정책을 최적화해야 합니다.

3. 에러 처리

토큰 부족 시 "INSUFFICIENT_TOKEN" 에러 코드 반환
동시성 충돌 발생 시 "CONCURRENT_MODIFICATION" 에러 코드 반환
API 호출 실패 시 자동 환불 처리, 환불 실패 시 별도 로그 기록

4. 확장 가이드

새로운 AI 서비스 추가 시 ai_services 테이블에 등록 필요
WorksheetService도 RoadmapService와 동일한 패턴으로 토큰 시스템 연동 필요

💻 코드 주요 변경 사항
1. AiUsage 엔티티 확장
java복사@Entity
@Table(name = "ai_usages")
@Builder
@NoArgsConstructor
@AllArgsConstructor
@Getter
public class AiUsage extends BaseEntity {
    // 기존 필드...
    private Long tokenCost;
    
    // 추가된 필드
    private Long actualTokenUsage;
    
    // 기존 메서드...
    
    // 추가된 메서드
    public void recordActualTokenUsage(Long actualTokenUsage) {
        this.actualTokenUsage = actualTokenUsage;
    }
}
2. TokenUsageService 확장
java복사@Transactional
public void updateActualTokenUsage(Long usageId, Long actualTokenUsage) {
    AiUsage usage = aiUsageRepository.findById(usageId)
            .orElseThrow(() -> TokenException.of(TokenErrorCode.AI_USAGE_NOT_FOUND));
    
    usage.recordActualTokenUsage(actualTokenUsage);
    aiUsageRepository.save(usage);
    
    log.info("실제 토큰 사용량 업데이트: {}", usageId);
}
3. RoadmapService 통합
java복사@Async
public CompletableFuture<WeeklyRoadmapResponse> generateWeeklyRoadmapAsync(RoadmapRequest request, Long memberId) {
    return CompletableFuture.supplyAsync(() -> {
        log.info("로드맵 생성 시작");
        Long usageId = null;

        try {
            // 프롬프트 생성
            String prompt = promptService.createPrompt(request);
            
            // 토큰 사용 요청
            UseTokenRequest tokenRequest = UseTokenRequest.builder()
                .aiServiceId(ROADMAP_SERVICE_ID)
                .requestData(prompt)
                .build();
                
            AiUsageResponse usageResponse = tokenFacadeService.useTokenForAiService(memberId, tokenRequest);
            usageId = usageResponse.getId();
            
            // OpenAI API 호출
            // ... (생략)
            
            // 실제 사용량 업데이트
            tokenFacadeService.updateActualTokenUsage(usageId, usage.getTotalTokens());
            
            // 사용 완료 처리
            tokenFacadeService.markAiUsageAsCompleted(usageId);
            
            return response;
        } catch (Exception e) {
            // 실패 시 환불 처리
            if (usageId != null) {
                tokenFacadeService.markAiUsageAsFailed(usageId);
            }
            throw new RuntimeException("로드맵 생성 실패", e);
        }
    });
}
이 PR을 통해 고정 가격 모델 기반의 토큰 시스템이 AI 로드맵 서비스에 성공적으로 통합되었으며, 서비스 사용량 모니터링과 안정적인 과금 처리가 가능해졌습니다.