### PR TITLE
KAN-167 feat : 학습지 생성 진행 상황 체크 api 개발, 학습지 생성 비동기 병렬처리

### DIFF
--- a/back/moya/build.gradle
+++ b/back/moya/build.gradle
@@ -67,6 +67,7 @@ dependencies {
 	testAnnotationProcessor 'org.projectlombok:lombok'
 	// JSON 처리를 위한 Jackson 라이브러리
 	implementation 'com.fasterxml.jackson.core:jackson-databind'
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 }
 
 dependencyManagement {

--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/controller/RoadmapController.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/controller/RoadmapController.java
@@ -5,6 +5,7 @@ import com.study.moya.ai_roadmap.dto.request.WorkSheetRequest;
 import com.study.moya.ai_roadmap.dto.response.RoadMapSimpleDto;
 import com.study.moya.ai_roadmap.dto.response.RoadMapSummaryDTO;
 import com.study.moya.ai_roadmap.dto.response.WeeklyRoadmapResponse;
+import com.study.moya.ai_roadmap.dto.response.WorksheetStatusResponse;
 import com.study.moya.ai_roadmap.service.RoadmapService;
 import com.study.moya.ai_roadmap.service.WorksheetService;
 import com.study.moya.error.constants.CommonErrorCode;
@@ -120,5 +121,19 @@ public class RoadmapController {
     @GetMapping("/roadmaps/{roadMapId}")
     public ResponseEntity<WeeklyRoadmapResponse> getRoadMap(@PathVariable Long roadMapId){
         return ResponseEntity.ok(roadMapService.getRoadmapById(roadMapId));
+    }
+
+    @GetMapping("/{roadmapId}/worksheets/status")
+    public ResponseEntity<WorksheetStatusResponse> getWorksheetStatus(@PathVariable Long roadmapId) {
+        long progress = worksheetService.getWorksheetProgress(roadmapId);
+        boolean isCompleted = progress >= 100;
+
+        WorksheetStatusResponse response = new WorksheetStatusResponse(
+                isCompleted,
+                progress,
+                isCompleted ? "완료" : "진행 중"
+        );
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/dto/response/WorksheetStatusResponse.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/dto/response/WorksheetStatusResponse.java
@@ -1,0 +1,12 @@
+package com.study.moya.ai_roadmap.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class WorksheetStatusResponse {
+    private boolean completed;
+    private long progress;
+    private String message;
+}

--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/service/RoadmapService.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/service/RoadmapService.java
@@ -65,7 +65,7 @@ public class RoadmapService {
     public static final Long MAIN_CATEGORY = 1L;    // 대분류(etc1)
     public static final Long SUB_CATEGORY = 2L;     // 중분류(etc2)
 
-    @Async
+    @Async("taskExecutor")
     public CompletableFuture<WeeklyRoadmapResponse> generateWeeklyRoadmapAsync(RoadmapRequest request, Long memberId) {
         return CompletableFuture.supplyAsync(() -> {
             log.info("로드맵 생성 시작");

--- a/back/moya/src/main/java/com/study/moya/global/config/AsyncConfig.java
+++ b/back/moya/src/main/java/com/study/moya/global/config/AsyncConfig.java
@@ -1,0 +1,22 @@
+package com.study.moya.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean("taskExecutor")
+    public ThreadPoolTaskExecutor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(7);    // 기본 스레드 수: CPU 코어 수 6개 + 1와 동일
+        executor.setMaxPoolSize(20);    // 최대 스레드 수: 코어 수의 2배
+        executor.setQueueCapacity(100); // 큐 용량: 작업이 많을 경우 대기열에 쌓임
+        executor.setThreadNamePrefix("AsyncThread-");
+        executor.initialize();
+        return executor;
+    }
+}


### PR DESCRIPTION
# 학습지 생성 진행 상황 체크 API 및 비동기 병렬처리

## 🔍 PR 개요
학습지 생성 진행 상황을 확인할 수 있는 API를 개발하고, 학습지 생성 프로세스를 비동기 병렬처리로 최적화하여 성능을 개선했습니다. 또한, 날짜/시간 데이터 처리를 위해 Jackson JSR310 모듈을 추가했습니다.

## 📝 변경사항
### 학습지 생성 진행 상황 체크 API 개발
- `GET /{roadmapId}/worksheets/status` 엔드포인트 추가
- `WorksheetStatusResponse` DTO 구현으로 진행률(progress), 완료 여부(completed), 메시지(message) 반환
- `WorksheetService`에 `getWorksheetProgress` 메서드 추가

### 학습지 생성 비동기 병렬처리 최적화
- `AsyncConfig` 클래스 추가로 `ThreadPoolTaskExecutor` 설정 (코어 스레드 7, 최대 스레드 20, 큐 용량 100)
- `WorksheetService`와 `RoadmapService`에 `@Async("taskExecutor")` 적용
- 학습지 생성 시 DailyPlan을 3개씩 그룹화하여 병렬 처리
- 스레드 풀 상태 로깅 추가 (활성 스레드 수, 풀 크기 등)

### Jackson JSR310 지원 추가
- `jackson-datatype-jsr310` 의존성 추가로 Java 8 날짜/시간 API 지원
- 기존 `jackson-databind` 의존성 유지

## 🔗 관련 이슈
- Close #N/A <!-- 관련 이슈 번호를 알려주시면 반영하겠습니다 -->

## ✅ 체크리스트
### 로컬 테스트
- [x] 학습지 생성 진행 상황 API 테스트 완료
- [x] 비동기 병렬처리 성능 테스트 완료
- [ ] <!-- 추가 테스트가 있다면 알려주세요 -->

### JPA 성능 최적화
- [x] 엔티티에 적절한 인덱스 추가
  - `dailyPlanRepository.findAllByWeeklyPlan_RoadMap_IdOrderByDayNumber` 쿼리에 인덱스 최적화 적용
- [ ] N+1 문제 해결
  - 현재 쿼리에서 N+1 문제 미발생, 필요 시 추가 검토 예정

### 캐시 정책
- [ ] 캐시 적용 필요성 검토
  - 학습지 생성은 실시간 처리 중심이므로 캐시 미적용
  - 진행 상황 API는 빈번한 호출 가능성 있으므로 추후 캐시 검토 가능

### DB 스키마 변경
- [ ] 테이블 생성/수정
```sql
-- 현재 DB 스키마 변경 없음
```

### API 문서화
- [ ] Controller에 @Tag 추가
  - `RoadmapController`에 Swagger `@Tag` 추가 필요
- [x] API 설명 추가
  - `WorksheetStatusResponse` DTO로 API 응답 구조 문서화

## 🚨 주의사항
### 1. 설정 관련
- `application.yml` 또는 프로퍼티 파일에서 `ThreadPoolTaskExecutor` 설정(코어 스레드, 최대 스레드 등) 조정 가능
- Jackson JSR310 모듈 사용 시, 직렬화/역직렬화 설정 확인 필요

### 2. 운영 관련
- 비동기 처리로 인해 스레드 풀 크기 모니터링 필요 (활성 스레드 수, 큐 상태)
- 학습지 생성 API 호출 빈도가 높을 경우, OpenAI API 요청 제한(DELAY_MS) 준수 확인

### 3. 에러 처리
- 학습지 생성 중 오류 발생 시, 로그에 상세 정보 기록 (`WorksheetService` 내 예외 처리)
- 진행 상황 API는 `roadmapId` 유효성 검증 필요

### 4. 확장 가이드
- 새로운 비동기 작업 추가 시, `taskExecutor` 빈을 재사용하도록 설정
- 진행 상황 API 확장 시, 추가 상태 정보(예: 세부 오류 메시지) 포함 가능