### PR TITLE
KAN-187 feat : 인기 게시글 조회 및 조회수 동시성 처리 + HOTFIX: 스웨거 에러처리

### DIFF
--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/controller/RoadmapController.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/controller/RoadmapController.java
@@ -8,6 +8,7 @@ import com.study.moya.ai_roadmap.dto.response.WeeklyRoadmapResponse;
 import com.study.moya.ai_roadmap.dto.response.WorksheetStatusResponse;
 import com.study.moya.ai_roadmap.service.RoadmapService;
 import com.study.moya.ai_roadmap.service.WorksheetService;
+import com.study.moya.error.constants.AuthErrorCode;
 import com.study.moya.error.constants.CommonErrorCode;
 import com.study.moya.swagger.annotation.SwaggerErrorDescription;
 import com.study.moya.swagger.annotation.SwaggerErrorDescriptions;
@@ -100,7 +101,7 @@ public class RoadmapController {
     @Operation(summary = "내 로드맵 목록 조회", description = "현재 로그인한 회원의 로드맵 목록을 조회합니다.")
     @SwaggerSuccessResponse(value = List.class, name = "내 로드맵 목록 조회 성공")
     @SwaggerErrorDescriptions({
-            @SwaggerErrorDescription(name = "인증 필요", description = "로그인이 필요한 서비스입니다.", value = CommonErrorCode.class, code = "UNAUTHORIZED")
+            @SwaggerErrorDescription(name = "인증 필요", description = "로그인이 필요한 서비스입니다.", value = AuthErrorCode.class, code = "UNAUTHORIZED")
     })
     @GetMapping("/myroadmaps")
     public ResponseEntity<?> getMyRoadmaps(@AuthenticationPrincipal Long memberId) {

--- a/back/moya/src/main/java/com/study/moya/posts/controller/PostController.java
+++ b/back/moya/src/main/java/com/study/moya/posts/controller/PostController.java
@@ -2,10 +2,7 @@ package com.study.moya.posts.controller;
 
 import com.study.moya.global.api.ApiResponse;
 import com.study.moya.posts.dto.like.LikeResponse;
-import com.study.moya.posts.dto.post.PostCreateRequest;
-import com.study.moya.posts.dto.post.PostDetailResponse;
-import com.study.moya.posts.dto.post.PostListResponse;
-import com.study.moya.posts.dto.post.PostUpdateRequest;
+import com.study.moya.posts.dto.post.*;
 import com.study.moya.posts.service.PostService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -105,5 +102,12 @@ public class PostController {
                                                                 @AuthenticationPrincipal Long memberId) {
         LikeResponse likeResponse = postService.removeLike(postId, memberId);
         return ResponseEntity.ok(ApiResponse.of(likeResponse));
+    }
+
+    @GetMapping("/popular")
+    public ResponseEntity<ApiResponse<List<PopularListResponse>>> getPopularPosts() {
+        log.info("인기 게시글 조회");
+        List<PopularListResponse> popularPosts = postService.getPopularPosts();
+        return ResponseEntity.ok(ApiResponse.of(popularPosts));
     }
 }

--- a/back/moya/src/main/java/com/study/moya/posts/domain/Post.java
+++ b/back/moya/src/main/java/com/study/moya/posts/domain/Post.java
@@ -17,7 +17,8 @@ import java.util.Set;
 @Table(name = "posts",
         indexes = {
                 @Index(name = "idx_created_at", columnList = "createdAt"),
-                @Index(name = "idx_title", columnList = "title")
+                @Index(name = "idx_title", columnList = "title"),
+                @Index(name = "idx_is_deleted_views", columnList = "isDeleted, views")  // 추가된 복합 인덱스
         })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/back/moya/src/main/java/com/study/moya/posts/dto/post/PopularListResponse.java
+++ b/back/moya/src/main/java/com/study/moya/posts/dto/post/PopularListResponse.java
@@ -1,0 +1,31 @@
+package com.study.moya.posts.dto.post;
+
+import com.study.moya.posts.domain.Post;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+public record PopularListResponse(
+        Long postId,
+        String title,
+        @Schema(example = "모집 마감 일자")
+        String endDate,
+        @Schema(example = "대분류")
+        Set<String> studies,
+        @Schema(example = "중분류")
+        Set<String> studyDetails,
+        Integer views
+) {
+    public static PopularListResponse from(Post post) {
+        return new PopularListResponse(
+                post.getId(),
+                post.getTitle(),
+                String.valueOf(post.getEndDate()),
+                post.getStudies(),
+                post.getStudyDetails(),
+                post.getViews()
+        );
+
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/posts/repository/PostRepository.java
+++ b/back/moya/src/main/java/com/study/moya/posts/repository/PostRepository.java
@@ -2,14 +2,20 @@ package com.study.moya.posts.repository;
 
 import com.study.moya.member.domain.Member;
 import com.study.moya.posts.domain.Post;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
@@ -18,4 +24,12 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     int countByAuthor(Member member);
 
     List<Post> findByAuthor(@Param("author") Member author);
+
+    @Query("SELECT p FROM Post p WHERE p.isDeleted = false ORDER BY p.views DESC")
+    List<Post> findTop10ByIsDeletedFalseOrderByViewsDesc();
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({@QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000")}) // 3초 락 타임아웃 (선택 사항)
+    Optional<Post> findWithLockById(Long postId);
+
 }

--- a/back/moya/src/main/java/com/study/moya/posts/service/PostService.java
+++ b/back/moya/src/main/java/com/study/moya/posts/service/PostService.java
@@ -1,15 +1,14 @@
 package com.study.moya.posts.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.study.moya.global.api.ApiResponse;
 import com.study.moya.member.domain.Member;
 import com.study.moya.posts.domain.Comment;
 import com.study.moya.posts.domain.Like;
 import com.study.moya.posts.domain.Post;
 import com.study.moya.posts.dto.like.LikeResponse;
-import com.study.moya.posts.dto.post.PostCreateRequest;
-import com.study.moya.posts.dto.post.PostDetailResponse;
-import com.study.moya.posts.dto.post.PostListResponse;
-import com.study.moya.posts.dto.post.PostUpdateRequest;
+import com.study.moya.posts.dto.post.*;
 import com.study.moya.posts.exception.PostErrorCode;
 import com.study.moya.posts.exception.PostException;
 import com.study.moya.posts.repository.LikeRepository;
@@ -21,10 +20,16 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.annotation.Schedules;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -34,6 +39,9 @@ public class PostService {
     private final PostRepository postRepository;
     private final LikeRepository likeRepository;
     private final com.study.moya.member.repository.MemberRepository memberRepository;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    private static final String POPULAR_POSTS_KEY = "popular:posts";
 
     @Transactional
     public Long createPost(PostCreateRequest request, Long memberId) {
@@ -104,7 +112,7 @@ public class PostService {
 
     @Transactional
     public ApiResponse<PostDetailResponse> getPostDetail(Long postId, Long memberId) {
-        Post post = postRepository.findById(postId)
+        Post post = postRepository.findWithLockById(postId)
                 .orElseThrow(() -> PostException.of(PostErrorCode.POST_NOT_FOUND));
 
         if (post.getIsDeleted()) {
@@ -149,7 +157,7 @@ public class PostService {
                 commentDetails,
                 totalComments,
                 isLiked,
-                likeRepository.countByPostId(postId)
+                post.getLikes().size()
         );
 
         return ApiResponse.of(detailResponse);
@@ -272,4 +280,68 @@ public class PostService {
 
         return new LikeResponse(false, totalLikes);
     }
+
+    /**
+     * 5분마다 인기 글 저장 (조회수 기준)
+     */
+    @Scheduled(fixedRate = 300000)
+    public void refreshPopularPosts() {
+        // 인기글 Top 10 조회 (인덱스 활용)
+        List<Post> popularPosts = postRepository.findTop10ByIsDeletedFalseOrderByViewsDesc();
+
+        // 레디스에 저장할 데이터 준비
+        List<PopularListResponse> postResponses = popularPosts.stream()
+                .map(PopularListResponse::from)
+                .toList();
+
+        redisTemplate.delete(POPULAR_POSTS_KEY);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        for (PopularListResponse post : postResponses) {
+            try {
+                // 객체를 Json으로 파싱
+                String postJson = objectMapper.writeValueAsString(post);
+                redisTemplate.opsForList().rightPush(POPULAR_POSTS_KEY, postJson);
+            } catch (JsonProcessingException e) {
+                log.error("JSON 파싱 오류: {}", e.getMessage());
+            }
+        }
+
+        redisTemplate.expire(POPULAR_POSTS_KEY, 300, TimeUnit.SECONDS);
+
+        log.info("Redis 캐시에 인기 게시글 업데이트 완료");
+    }
+
+    /**
+     * Redis 에서 인기 글 조회 (조회수 기준)
+     * @return 인기 글 목록
+     */
+    public List<PopularListResponse> getPopularPosts() {
+        List<Object> cachedPosts = redisTemplate.opsForList().range(POPULAR_POSTS_KEY, 0, -1);
+
+        if (cachedPosts == null || cachedPosts.isEmpty()) {
+            log.info("인기 게시글 관련 레디스에 데이터가 없다. refresh 메서드 재요청");
+            refreshPopularPosts();
+            cachedPosts = redisTemplate.opsForList().range(POPULAR_POSTS_KEY, 0, -1);
+        }
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        List<PopularListResponse> result = new ArrayList<>();
+
+        for (Object cachedPost : cachedPosts) {
+            try {
+                // Json 을 객체로 파싱
+                PopularListResponse post = objectMapper.readValue(cachedPost.toString(), PopularListResponse.class);
+                result.add(post);
+            } catch (JsonProcessingException e) {
+                log.error("JSON 파싱 오류: {}", e.getMessage());
+            }
+        }
+
+        return result;
+
+    }
+
+
 }


### PR DESCRIPTION
# 인기 게시글 조회 및 조회수 동시성 처리 + Swagger 에러 처리

## 🔍 PR 개요
- 인기 게시글 조회 기능을 추가하고, 조회수 증가 시 동시성 문제를 해결하기 위해 비관적 락을 적용했습니다.
- Swagger 에러 코드에서 `CommonErrorCode`를 `AuthErrorCode`로 수정하여 인증 관련 에러를 정확히 반영했습니다.

## 📝 변경사항
### 주요 기능 1 구현: 인기 게시글 조회
- **PostController**: `/popular` 엔드포인트 추가하여 인기 게시글 목록을 조회.
- **PostService**: Redis를 활용해 조회수 기준 상위 10개 게시글을 캐싱하고, 5분마다 갱신하는 `refreshPopularPosts` 메서드 구현.
- **PostRepository**: 조회수 기준 상위 10개 게시글을 조회하는 `findTop10ByIsDeletedFalseOrderByViewsDesc` 메서드 추가.
- **PopularListResponse**: 인기 게시글 데이터를 반환하기 위한 DTO 추가.

### 주요 기능 2 구현: 조회수 동시성 처리
- **PostRepository**: 조회수 증가 시 동시성 문제를 해결하기 위해 비관적 락(`PESSIMISTIC_WRITE`)과 3초 타임아웃을 적용한 `findWithLockById` 메서드 추가.
- **PostService**: 게시글 상세 조회(`getPostDetail`) 시 `findWithLockById`를 사용하여 동시성 제어.

### 주요 기능 3 구현: Swagger 에러 처리 (HOTFIX)
- **RoadmapController**: `getMyRoadmaps` API의 Swagger 에러 코드에서 `CommonErrorCode.UNAUTHORIZED`를 `AuthErrorCode.UNAUTHORIZED`로 수정하여 인증 에러를 명확히 표시.

## 🔗 관련 이슈
- Close #KAN-187 인기 게시글 조회 및 조회수 동시성 처리
- Close #KAN-188 Swagger 에러 코드 수정

## ✅ 체크리스트
### 로컬 테스트
- [x] 인기 게시글 조회 테스트 완료
- [x] 조회수 동시성 처리 테스트 완료
- [x] Swagger 에러 코드 수정 테스트 완료

### JPA 성능 최적화
- [x] 엔티티에 적절한 인덱스 추가
  - `Post` 엔티티에 `isDeleted`와 `views`를 포함한 복합 인덱스(`idx_is_deleted_views`) 추가하여 인기 게시글 조회 성능 최적화.
- [x] N+1 문제 해결
  - `findTop10ByIsDeletedFalseOrderByViewsDesc` 쿼리에서 불필요한 조인을 제거하고, 단일 쿼리로 데이터 조회.

### 캐시 정책
- [x] 캐시 적용 필요성 검토
  - **검토 결과**: 인기 게시글 조회는 빈번히 호출되므로 Redis를 활용한 캐싱 적용.
  - **적용 방안**: Redis List에 인기 게시글 데이터를 JSON 형태로 저장, 5분 TTL 설정 및 주기적 갱신.

### DB 스키마 변경
- [x] 테이블 생성/수정
```sql
-- Post 테이블에 복합 인덱스 추가
CREATE INDEX idx_is_deleted_views ON posts (isDeleted, views);
```

### API 문서화
- [ ] Controller에 @Tag 추가
  - `PostController`에 인기 게시글 조회 API 태그 추가.
- [x] API 설명 추가
  - `PopularListResponse` DTO에 Swagger `@Schema` 어노테이션 추가하여 필드 설명 제공.

## 🚨 주의사항
### 1. 설정 관련
- Redis 서버가 정상적으로 실행 중이어야 하며, `application.yml`에 Redis 연결 설정이 필요합니다.
- Redis 연결 정보: `spring.redis.host`, `spring.redis.port` 확인.

### 2. 운영 관련
- 인기 게시글 캐시 갱신 주기는 5분으로 설정되어 있으며, 필요 시 `fixedRate` 값을 조정.
- 비관적 락 타임아웃은 3초로 설정되어 있으므로, 높은 트래픽 환경에서 타임아웃 발생 가능성 모니터링 필요.

### 3. 에러 처리
- Redis 연결 실패 시, `refreshPopularPosts` 메서드가 재시도하지 않으므로 로깅을 통해 에러 추적.
- JSON 파싱 오류 발생 시, 로그에 기록되며 빈 캐시 데이터 반환 방지.

### 4. 확장 가이드
- 인기 게시글 조회 기준(예: 좋아요 수, 댓글 수 등)을 추가하려면 `PostRepository`의 쿼리와 `PopularListResponse` DTO를 확장.
- 비관적 락 대신 낙관적 락을 사용하려면 `Post` 엔티티에 `@Version` 어노테이션을 추가하고, `PostService`에서 락 로직 수정.