### PR TITLE
Kan 207 티켓 스케쥴러 티켓처리

### DIFF
--- a/back/moya/src/main/java/com/study/moya/MoyaApplication.java
+++ b/back/moya/src/main/java/com/study/moya/MoyaApplication.java
@@ -3,8 +3,10 @@ package com.study.moya;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 //test
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
 public class MoyaApplication {

--- a/back/moya/src/main/java/com/study/moya/ai_roadmap/controller/RoadmapController.java
+++ b/back/moya/src/main/java/com/study/moya/ai_roadmap/controller/RoadmapController.java
@@ -82,9 +82,10 @@ public class RoadmapController {
     }
 
     @PostMapping("/{roadmapId}/worksheets")
-    public ResponseEntity<Void> generateWorksheets(@PathVariable Long roadmapId, @Valid @RequestBody WorkSheetRequest request) {
-        log.info("로드맵 ID: {}의 학습지 생성 시작", roadmapId);
-        worksheetService.generateAllWorksheets(roadmapId, request)
+    public ResponseEntity<Void> generateWorksheets(@PathVariable Long roadmapId, @Valid @RequestBody WorkSheetRequest request, 
+                                                  @AuthenticationPrincipal Long memberId) {
+        log.info("로드맵 ID: {}의 학습지 생성 시작, 회원 ID: {}", roadmapId, memberId);
+        worksheetService.generateAllWorksheets(roadmapId, request, memberId)
                 .thenRun(() -> log.info("로드맵 ID: {}의 학습지 생성 완료", roadmapId))
                 .exceptionally(ex -> {
                     log.error("학습지 생성 중 오류 발생: {}", ex.getMessage());

--- a/back/moya/src/main/java/com/study/moya/mypage/dto/MyPageResponse.java
+++ b/back/moya/src/main/java/com/study/moya/mypage/dto/MyPageResponse.java
@@ -18,12 +18,28 @@ public class MyPageResponse {
 
     @Schema(description = "자기소개", example = "안녕하세요, 백엔드 개발자입니다.")
     private String introduction;
+    
+    @Schema(description = "로드맵 티켓 잔액", example = "10")
+    private Long roadmapTicketBalance;
+    
+    @Schema(description = "워크시트 티켓 잔액", example = "5")
+    private Long worksheetTicketBalance;
 
     public static MyPageResponse from(Member member) {
         MyPageResponse response = new MyPageResponse();
         response.nickname = member.getNickname();
         response.profileImageUrl = member.getProfileImageUrl();
         response.introduction = member.getIntroduction();
+        return response;
+    }
+    
+    public static MyPageResponse from(Member member, Long roadmapTicketBalance, Long worksheetTicketBalance) {
+        MyPageResponse response = new MyPageResponse();
+        response.nickname = member.getNickname();
+        response.profileImageUrl = member.getProfileImageUrl();
+        response.introduction = member.getIntroduction();
+        response.roadmapTicketBalance = roadmapTicketBalance;
+        response.worksheetTicketBalance = worksheetTicketBalance;
         return response;
     }
 }

--- a/back/moya/src/main/java/com/study/moya/mypage/service/MyPageService.java
+++ b/back/moya/src/main/java/com/study/moya/mypage/service/MyPageService.java
@@ -9,6 +9,8 @@ import com.study.moya.mypage.dto.MyPageResponse;
 import com.study.moya.mypage.dto.MyPageUpdateRequest;
 import com.study.moya.mypage.exception.MyPageErrorCode;
 import com.study.moya.mypage.exception.MyPageException;
+import com.study.moya.token.domain.enums.TicketType;
+import com.study.moya.token.service.ticket.TicketFacadeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
@@ -19,11 +21,21 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class MyPageService {
     private final MemberRepository memberRepository;
+    private final TicketFacadeService ticketFacadeService;
 
+    @Transactional  // 티켓 계정 생성을 위해 쓰기 가능한 트랜잭션으로 변경
     public MyPageResponse getMyPageInfo(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> MyPageException.of(MyPageErrorCode.MEMBER_NOT_FOUND));
-        return MyPageResponse.from(member);
+        
+        // 티켓 계정이 없으면 자동으로 생성
+        ticketFacadeService.getOrCreateTicketAccount(memberId);
+        
+        // 각 티켓 타입별 잔액 조회
+        Long roadmapTicketBalance = ticketFacadeService.getTicketBalance(memberId, TicketType.ROADMAP_TICKET);
+        Long worksheetTicketBalance = ticketFacadeService.getTicketBalance(memberId, TicketType.WORKSHEET_TICKET);
+        
+        return MyPageResponse.from(member, roadmapTicketBalance, worksheetTicketBalance);
     }
 
     @Transactional

--- a/back/moya/src/main/java/com/study/moya/token/service/scheduler/WeeklyTicketScheduler.java
+++ b/back/moya/src/main/java/com/study/moya/token/service/scheduler/WeeklyTicketScheduler.java
@@ -1,0 +1,115 @@
+package com.study.moya.token.service.scheduler;
+
+import com.study.moya.admin.service.AdminTicketService;
+import com.study.moya.member.domain.Member;
+import com.study.moya.member.domain.MemberStatus;
+import com.study.moya.member.repository.MemberRepository;
+import com.study.moya.token.domain.enums.TicketType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WeeklyTicketScheduler {
+
+    private final MemberRepository memberRepository;
+    private final AdminTicketService adminTicketService;
+    
+    private static final int WEEKLY_ROADMAP_TICKETS = 10;
+    private static final int WEEKLY_WORKSHEET_TICKETS = 10;
+
+    /**
+     * 매일 오전 9시에 실행되어 가입일 기준 주간 티켓을 지급합니다.
+     */
+    @Scheduled(cron = "0 0 9 * * *")
+    @Transactional
+    public void distributeWeeklyTickets() {
+        log.info("주간 티켓 지급 스케줄러 시작");
+        
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime oneWeekAgo = now.minus(7, ChronoUnit.DAYS);
+        
+        // 가입한 지 1주일 이상 된 모든 활성 회원 조회
+        List<Member> eligibleMembers = memberRepository.findByStatus(MemberStatus.ACTIVE);
+        
+        int processedCount = 0;
+        int skippedCount = 0;
+        
+        for (Member member : eligibleMembers) {
+            try {
+                if (shouldReceiveWeeklyTickets(member, now)) {
+                    distributeTicketsToMember(member);
+                    processedCount++;
+                } else {
+                    skippedCount++;
+                }
+            } catch (Exception e) {
+                log.error("회원 ID: {}에게 주간 티켓 지급 중 오류 발생", member.getId(), e);
+            }
+        }
+        
+        log.info("주간 티켓 지급 완료. 지급: {}명, 건너뜀: {}명", processedCount, skippedCount);
+    }
+
+    /**
+     * 회원이 주간 티켓을 받을 자격이 있는지 확인
+     */
+    private boolean shouldReceiveWeeklyTickets(Member member, LocalDateTime now) {
+        LocalDateTime joinDate = member.getCreatedAt();
+        
+        // 가입한 지 1주일 미만이면 지급하지 않음
+        if (ChronoUnit.DAYS.between(joinDate, now) < 7) {
+            return false;
+        }
+        
+        // 가입일로부터 경과된 주 수 계산
+        long daysSinceJoin = ChronoUnit.DAYS.between(joinDate, now);
+        long weeksSinceJoin = daysSinceJoin / 7;
+        
+        // 오늘이 해당 주차의 지급일인지 확인 (가입일 기준)
+        long todaysSinceJoin = ChronoUnit.DAYS.between(joinDate, now.toLocalDate().atStartOfDay());
+        return todaysSinceJoin % 7 == 0 && todaysSinceJoin >= 7;
+    }
+
+    /**
+     * 특정 회원에게 주간 티켓 지급
+     */
+    private void distributeTicketsToMember(Member member) {
+        Long memberId = member.getId();
+        
+        log.info("회원 ID: {}에게 주간 티켓 지급 시작", memberId);
+        
+        try {
+            // 로드맵 티켓 지급
+            adminTicketService.giveTicketsToMember(memberId, (long) WEEKLY_ROADMAP_TICKETS, TicketType.ROADMAP_TICKET, "주간 자동 지급");
+            log.info("회원 ID: {}에게 로드맵 티켓 {}개 지급", memberId, WEEKLY_ROADMAP_TICKETS);
+            
+            // 워크시트 티켓 지급
+            adminTicketService.giveTicketsToMember(memberId, (long) WEEKLY_WORKSHEET_TICKETS, TicketType.WORKSHEET_TICKET, "주간 자동 지급");
+            log.info("회원 ID: {}에게 워크시트 티켓 {}개 지급", memberId, WEEKLY_WORKSHEET_TICKETS);
+            
+            log.info("회원 ID: {}에게 주간 티켓 지급 완료", memberId);
+            
+        } catch (Exception e) {
+            log.error("회원 ID: {}에게 티켓 지급 중 오류 발생", memberId, e);
+            throw e;
+        }
+    }
+
+    /**
+     * 수동으로 모든 자격있는 회원에게 티켓 지급 (관리자용)
+     */
+    @Transactional
+    public void manualDistributeWeeklyTickets() {
+        log.info("수동 주간 티켓 지급 시작");
+        distributeWeeklyTickets();
+    }
+}

--- a/back/moya/src/main/java/com/study/moya/token/service/ticket/TicketAccountService.java
+++ b/back/moya/src/main/java/com/study/moya/token/service/ticket/TicketAccountService.java
@@ -94,8 +94,8 @@ public class TicketAccountService {
 
         TicketAccount ticketAccount = TicketAccount.builder()
                 .member(member)
-                .roadmapTicketBalance(0L)
-                .worksheetTicketBalance(0L)
+                .roadmapTicketBalance(10L)
+                .worksheetTicketBalance(10L)
                 .build();
 
         return ticketAccountRepository.save(ticketAccount);


### PR DESCRIPTION
# 스케쥴러 설정 및 학습지 토큰 처리 로직 구현

## 🔍 PR 개요
회원가입 후 마이페이지 조회 시 티켓 생성 기능과 주간 자동 티켓 지급을 위한 스케쥴러 구현, 그리고 학습지 생성 시 티켓 소모 로직을 추가했습니다.

## 📝 변경사항

### 주간 티켓 자동 지급 스케쥴러 구현
- 매일 오전 9시에 실행되는 스케쥴러 추가(요청 사항에 따른 각 메서드별 상세한 주석 처리)
- 가입일 기준으로 1주일마다 로드맵 티켓 10개, 워크시트 티켓 10개 자동 지급
- 회원별 가입일 기준 주기 계산 로직 구현

### 마이페이지 티켓 정보 조회 및 계정 자동 생성
- 마이페이지 조회 시 티켓 잔액 정보 포함하여 응답
- 티켓 계정이 없는 경우 자동으로 생성 (초기 잔액: 각 10개)
- 기존 회원 대상 티켓 계정 생성 지원

### 학습지 생성 시 티켓 소모 로직 추가
- 학습지 생성 전 워크시트 티켓 보유 여부 확인
- 티켓 부족 시 예외 처리 및 생성 중단
- 티켓 사용 내역 로깅 추가

## 🔗 관련 이슈
- Close #KAN-207 스케쥴러 설정 및 구현

## ✅ 체크리스트

### 로컬 테스트
- [x] 스케쥴러 동작 테스트 완료
- [x] 마이페이지 티켓 정보 조회 테스트 완료
- [x] 학습지 생성 시 티켓 소모 테스트 완료

### API 문서화
- [x] MyPageResponse에 티켓 잔액 필드 스키마 추가
- [x] 학습지 생성 API에 memberId 파라미터 추가

## 🚨 주의사항

### 1. 설정 관련
- `@EnableScheduling` 어노테이션이 MoyaApplication에 추가되어 스케쥴러 활성화
- 스케쥴러 실행 시간: 매일 오전 9시 (cron: "0 0 9 * * *")

### 2. 운영 관련
- 스케쥴러는 가입일 기준으로 정확히 1주일 후부터 지급 시작
- 대량의 회원이 있을 경우 스케쥴러 실행 시간이 길어질 수 있음
- 티켓 지급 실패 시에도 다른 회원 처리는 계속 진행됨

### 3. 에러 처리
- 학습지 생성 시 티켓 부족하면 `RuntimeException` 발생으로 생성 중단
- 스케쥴러 실행 중 개별 회원 처리 실패는 로그만 남기고 계속 진행
- 티켓 사용 실패 시 전체 학습지 생성 프로세스 롤백

### 4. 확장 가이드
- 티켓 지급량 변경: `WeeklyTicketScheduler`의 상수값 수정
- 지급 주기 변경: cron 표현식 및 `shouldReceiveWeeklyTickets` 로직 수정
- 새로운 티켓 타입 추가 시 스케쥴러 로직에도 반영 필요